### PR TITLE
Included reset endpoints

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -457,6 +457,30 @@ class Client:
                              f"/organizations/{validate_uuid(organization_id)}/members/"
                              f"{validate_uuid(member_id)}").json()
 
+    def reset_organization_member_mfa(self, organization_id: Union[UUID, str], member_id: Union[UUID, str]) -> bool:
+        """
+        Reset organization member MFA.
+        <https://api.zanshin.tenchisecurity.com/#operation/resetOrganizationMemberMfaById>
+        :param organization_id: the ID of the organization
+        :param member_id: the ID of the member
+        :return: a boolean if success
+        """
+        return self._request("POST",
+                             f"/organizations/{validate_uuid(organization_id)}/members/"
+                             f"{validate_uuid(member_id)}/mfa/reset").json()
+
+    def reset_delete_organization_password(self, organization_id: Union[UUID, str], member_id: Union[UUID, str]) -> bool:
+        """
+        Reset organization member Password.
+        <https://api.zanshin.tenchisecurity.com/#operation/resetOrganizationMemberPasswordById>
+        :param organization_id: the ID of the organization
+        :param member_id: the ID of the member
+        :return: a boolean if success
+        """
+        return self._request("POST",
+                             f"/organizations/{validate_uuid(organization_id)}/members/"
+                             f"{validate_uuid(member_id)}/password/reset").json()
+
     ###################################################
     # Organization Member Invite
     ###################################################

--- a/zanshinsdk/test_client.py
+++ b/zanshinsdk/test_client.py
@@ -579,6 +579,26 @@ class TestClient(unittest.TestCase):
             "DELETE", f"/organizations/{organization_id}/members/{member_id}"
         )
 
+    def test_reset_organization_member_mfa(self):
+        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
+        member_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
+
+        self.sdk.reset_organization_member_mfa(organization_id, member_id)
+
+        self.sdk._request.assert_called_once_with(
+            "POST", f"/organizations/{organization_id}/members/{member_id}/mfa/reset"
+        )
+
+    def test_reset_delete_organization_password(self):
+        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
+        member_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
+
+        self.sdk.reset_delete_organization_password(organization_id, member_id)
+
+        self.sdk._request.assert_called_once_with(
+            "POST", f"/organizations/{organization_id}/members/{member_id}/password/reset"
+        )
+
     ###################################################
     # Organization Member Invite
     ###################################################


### PR DESCRIPTION
### Describe the feature
Create two new functions `reset_organization_member_mfa` and `reset_delete_organization_password` using new endpoints that was created in PR(https://github.com/tenchi-security/zanshin-api/pull/705)

Fixes #37 