### PR TITLE
Update PyPI version when Github release is created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     name: Test and Coverage
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   zanshinsdk_jobs:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     name: Test and Coverage
     timeout-minutes: 10

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: Post coverage comment
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: [ "CI" ]
     types:
       - completed
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     name: Run tests & display coverage
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          sed -i 's/__PACKAGE_VERSION__/${{ github.event.release.tag_name }}/g' zanshinsdk/version.py setup.py 
+          make pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   deploy:
@@ -11,11 +11,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-python@v2
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel twine
+          pip install --upgrade setuptools wheel twine pandoc
+          python setup.py develop
+
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,24 +6,50 @@ on:
 
 jobs:
   deploy:
+    name: Test and Deploy to PyPI
+
     runs-on: ubuntu-latest
+
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel twine pandoc
-          python setup.py develop
+          python -m pip install --upgrade pip setuptools wheel
+          sed -i 's/__PACKAGE_VERSION__/${{ github.event.release.tag_name }}/g' zanshinsdk/version.py setup.py
+          python setup.py install
 
-      - name: Build and publish
+      - name: Unit tests
+        run: |
+          pip install -r requirements.txt
+          make test
+
+      - name: Generate updated documentation
+        run: |
+          sudo apt-get install -y pandoc
+          rm -f README.rst
+          make README.rst
+
+      - name: Build and publish to PyPI Test
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+          TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"
+        run: |
+          sudo apt-get install -y twine
+          make pypi
+
+      - name: Build and publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
         run: |
-          sed -i 's/__PACKAGE_VERSION__/${{ github.event.release.tag_name }}/g' zanshinsdk/version.py setup.py 
           make pypi

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,10 @@ README.rst: README.md
 
 pypi: README.rst sdist
 	python setup.py clean
-	twine upload --repository pypi dist/*
-
-pypitest: README.rst sdist
-	python setup.py clean
-	twine upload --repository pypitest dist/*
+	test -n "$(TWINE_REPOSITORY_URL)"  # TWINE_REPOSITORY_URL must be set
+	test -n "$(TWINE_USERNAME)"  # TWINE_USERNAME must be set
+	test -n "$(TWINE_PASSWORD)"  # TWINE_PASSWORD must be set
+	twine upload dist/*
 
 lint:
 	flake8 zanshinsdk --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,6 @@
 from pathlib import Path
-from os.path import join
-import re
 
 from setuptools import setup
-
-
-def get_version():
-    version_py = join('zanshinsdk', 'version.py')
-    regex = re.compile('__version__\s*=\s*[\'\"](?P<version>[\d\.]+)')
-    return regex.finditer(open(version_py, 'r', encoding='utf8').read()).__next__().group('version')
-
 
 extras = {
     'with_boto3': ['moto[all]~=3.1.16']
@@ -21,7 +12,7 @@ setup(
     long_description=Path('README.rst').read_text(encoding="utf8"),
     author='Tenchi Security',
     author_email='contact@tenchisecurity.com',
-    version=get_version(),
+    version='__PACKAGE_VERSION__',
     url='https://github.com/tenchi-security/zanshin-sdk-python',
     license='Apache Software License',
     install_requires=['httpx==0.23.0'],

--- a/zanshinsdk/version.py
+++ b/zanshinsdk/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.2.7'
+__version__ = '__PACKAGE_VERSION__'


### PR DESCRIPTION
Added new Github Actions workflow to auto-update source code with the release tag as the package version.

Already generated and configured the package-specific PyPI API token as a repository secret.

Tested using the existing unit tests and the equivalent process being executed for the CLI repo. Will not be able to test fully end-to-end until a new release is published.