### PR TITLE
Adds parameter to force-start a scan

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -807,17 +807,23 @@ class Client:
                              f"{validate_uuid(scan_target_id)}").json()
 
     def start_organization_scan_target_scan(self, organization_id: Union[UUID, str],
-                                            scan_target_id: Union[UUID, str]) -> bool:
+                                            scan_target_id: Union[UUID, str],
+                                            force: Optional[bool]) -> bool:
         """
         Starts a scan on the specified scan target.
         <https://api.zanshin.tenchisecurity.com/#operation/scanOrganizationScanTarget>
         :param organization_id: the ID of organization the scan target belongs to
         :param scan_target_id: the ID of the scan target
+        :param force: whether to force a scan that is in state NEW or INVALID_CREDENTIAL
         :return: a boolean if success
         """
+
+        body = {
+            "force": force
+        }
         return self._request("POST",
                              f"/organizations/{validate_uuid(organization_id)}/scantargets/"
-                             f"{validate_uuid(scan_target_id)}/scan").json()
+                             f"{validate_uuid(scan_target_id)}/scan", body=body).json()
 
     def stop_organization_scan_target_scan(self, organization_id: Union[UUID, str],
                                            scan_target_id: Union[UUID, str]) -> bool:

--- a/zanshinsdk/test_client.py
+++ b/zanshinsdk/test_client.py
@@ -923,10 +923,13 @@ class TestClient(unittest.TestCase):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         scan_target_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
 
-        self.sdk.start_organization_scan_target_scan(organization_id, scan_target_id)
+        self.sdk.start_organization_scan_target_scan(organization_id, scan_target_id, True)
 
         self.sdk._request.assert_called_once_with(
-            "POST", f"/organizations/{organization_id}/scantargets/{scan_target_id}/scan"
+            "POST", f"/organizations/{organization_id}/scantargets/{scan_target_id}/scan",
+            body={
+                "force": True
+            }
         )
 
     def test_stop_organization_scan_target_scan(self):
@@ -964,7 +967,7 @@ class TestClient(unittest.TestCase):
         self.sdk._request.assert_called_once_with(
             "GET", f"/organizations/{organization_id}/scantargets/{scan_target_id}/scans"
         )
-        
+
     @patch("zanshinsdk.client.isfile")
     @patch("zanshinsdk.Client._request")
     def test_iter_organization_scan_target_scans_response(self, request, mock_is_file):
@@ -2184,14 +2187,14 @@ class TestClient(unittest.TestCase):
         :param credential: ScanTargetAZURE
         :param boto3_profile: str
         :param schedule: str
-        
+
         :raises: Exception Onboard does\'t support given environment yet
 
 
         >>> self.sdk.onboard_scan_target(
                 region, organization_id, kind, name, credential, None, boto3_profile, schedule)
         raises:
-        >>> Onboard doesn't support AZURE environment yet 
+        >>> Onboard doesn't support AZURE environment yet
         """
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         kind = zanshinsdk.ScanTargetKind.AZURE
@@ -2210,7 +2213,7 @@ class TestClient(unittest.TestCase):
     @unittest.skipIf('HAVE_BOTO3', "requires not have boto3")
     def test_onboard_scan_target_aws_missing_boto3(self):
         """
-        Call onboard_scan_target without boto3 installed. 
+        Call onboard_scan_target without boto3 installed.
         Skip this test unless boto3 is installed in environment.
 
         :param region: str
@@ -2333,14 +2336,14 @@ class TestClient(unittest.TestCase):
         Skip this test unless boto3 is installed in environment.
         Mock the creation of a new Scan Target, and behavior of AWS Services STS, CloudFormation and S3.
 
-        :param region: str        
+        :param region: str
         :param organization_id: str
         :param kind: ScanTargetKind.AZURE
         :param credential: ScanTargetAZURE
         :param boto3_profile: str
         :param schedule: str
 
-        Asserts: 
+        Asserts:
         * New Scan Target was created, with given parameters.
         * Scan was Started for this new Scan Target.
         * CloudFormation with Zanshin Role was deployed sucessfully.
@@ -2414,7 +2417,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(zanshin_cloudformation_stack_name,
                          zanshin_stack['StackName'])
 
-        # Clean Up CloudFormation 
+        # Clean Up CloudFormation
         cf_stacks = cloudformation.describe_stacks(StackName=zanshin_cloudformation_stack_name)
         for cf_stack in cf_stacks['Stacks']:
             cloudformation.delete_stack(StackName=cf_stack['StackName'])
@@ -2431,14 +2434,14 @@ class TestClient(unittest.TestCase):
         Skip this test unless boto3 is installed in environment.
         Mock the creation of a new Scan Target, and behavior of AWS Services STS, CloudFormation and S3.
 
-        :param region: str        
+        :param region: str
         :param organization_id: str
         :param kind: ScanTargetKind.AZURE
         :param credential: ScanTargetAZURE
         :param boto3_profile: str
         :param schedule: str
 
-        Asserts: 
+        Asserts:
         * New Scan Target was created, with given parameters.
         * Scan was Started for this new Scan Target.
         * CloudFormation with Zanshin Role was deployed sucessfully.


### PR DESCRIPTION
Adds a parameter to force-start a scan, even if it's in state INVALID_CREDENTIAL or NEW.
This is to help with onboarding and to mimic the behavior of the Portal.

Tested: locally on a dev account.
