### PR TITLE
Updates scan target schedule format

### DIFF
--- a/zanshinsdk/__init__.py
+++ b/zanshinsdk/__init__.py
@@ -1,9 +1,10 @@
-from zanshinsdk.client import Client, AlertState, AlertSeverity, ScanTargetKind, Languages, ScanTargetAWS, \
-    ScanTargetAZURE, ScanTargetGCP, ScanTargetHUAWEI, ScanTargetDOMAIN, Roles, validate_uuid
+from zanshinsdk.client import Client, AlertState, AlertSeverity, ScanTargetKind, ScanTargetSchedule, Languages, \
+    ScanTargetAWS, ScanTargetAZURE, ScanTargetGCP, ScanTargetHUAWEI, ScanTargetDOMAIN, Roles, validate_uuid
 from zanshinsdk.iterator import AbstractPersistentAlertsIterator, PersistenceEntry
 from zanshinsdk.alerts_history import FilePersistentAlertsIterator
 from zanshinsdk.following_alerts_history import FilePersistentFollowingAlertsIterator
 from zanshinsdk.version import __version__
 
 import logging
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -55,14 +55,6 @@ class ScanTargetSchedule(str, Enum):
     TWENTY_FOUR_HOURS = '24h'
     SEVEN_DAYS = '7d'
 
-    _cron_conversion = {
-        '0 * * * *': ONE_HOUR,
-        '0 */6 * * *': SIX_HOURS,
-        '0 */12 * * *': TWELVE_HOURS,
-        '0 0 * * *': TWENTY_FOUR_HOURS,
-        '0 0 * * 0': SEVEN_DAYS
-    }
-
     @classmethod
     def from_value(cls, schedule: Union[str, ScanTargetSchedule]) -> ScanTargetSchedule:
         if isinstance(schedule, cls):

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 import time
 import logging
@@ -29,6 +30,7 @@ class AlertState(str, Enum):
     FALSE_POSITIVE = "FALSE_POSITIVE"
     CLOSED = "CLOSED"
 
+
 class AlertSeverity(str, Enum):
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
@@ -44,6 +46,49 @@ class ScanTargetKind(str, Enum):
     HUAWEI = "HUAWEI"
     DOMAIN = "DOMAIN"
     ORACLE = "ORACLE"
+
+
+class ScanTargetSchedule(str, Enum):
+    ONE_HOUR = '1h'
+    SIX_HOURS = '6h'
+    TWELVE_HOURS = '12h'
+    TWENTY_FOUR_HOURS = '24h'
+    SEVEN_DAYS = '7d'
+
+    _cron_conversion = {
+        '0 * * * *': ONE_HOUR,
+        '0 */6 * * *': SIX_HOURS,
+        '0 */12 * * *': TWELVE_HOURS,
+        '0 0 * * *': TWENTY_FOUR_HOURS,
+        '0 0 * * 0': SEVEN_DAYS
+    }
+
+    @classmethod
+    def from_value(cls, schedule: Union[str, ScanTargetSchedule]) -> ScanTargetSchedule:
+        if isinstance(schedule, cls):
+            return schedule
+        elif isinstance(schedule, str):
+            # try to match with current enum values
+            try:
+                return cls(schedule.lower())
+            except ValueError:
+                pass
+
+            # failing that, let's convert cron format to the new one
+            if schedule == '0 * * * *':
+                return cls.ONE_HOUR
+            elif schedule == '0 */6 * * *':
+                return cls.SIX_HOURS
+            elif schedule == '0 */12 * * *':
+                return cls.TWELVE_HOURS
+            elif schedule == '0 0 * * *':
+                return cls.TWENTY_FOUR_HOURS
+            elif schedule == '0 0 * * 0':
+                return cls.SEVEN_DAYS
+            else:
+                raise ValueError(f"Unexpected schedule value '{schedule}'")
+        else:
+            raise TypeError("schedule must be a string or an instance of ScanTargetSchedule")
 
 
 class ScanTargetAWS(dict):
@@ -74,7 +119,8 @@ class ScanTargetDOMAIN(dict):
 
 class ScanTargetORACLE(dict):
     def __init__(self, compartment_id, region, tenancy_id, user_id, key_fingerprint):
-        dict.__init__(self, compartment_id=compartment_id, region=region, tenancy_id=tenancy_id, user_id=user_id, key_fingerprint=key_fingerprint)
+        dict.__init__(self, compartment_id=compartment_id, region=region, tenancy_id=tenancy_id, user_id=user_id,
+                      key_fingerprint=key_fingerprint)
 
 
 class Roles(str, Enum):
@@ -718,7 +764,8 @@ class Client:
     def create_organization_scan_target(self, organization_id: Union[UUID, str], kind: ScanTargetKind, name: str,
                                         credential: Union[ScanTargetAWS, ScanTargetAZURE, ScanTargetGCP,
                                                           ScanTargetHUAWEI, ScanTargetDOMAIN, ScanTargetORACLE],
-                                        schedule: str = "0 0 * * *") -> Dict:
+                                        schedule: Union[
+                                            str, ScanTargetSchedule] = ScanTargetSchedule.TWENTY_FOUR_HOURS) -> Dict:
         """
         Create a new scan target in organization.
         <https://api.zanshin.tenchisecurity.com/#operation/createOrganizationScanTargets>
@@ -730,12 +777,11 @@ class Client:
             * For Azure scan targets, provide *applicationId*, *subscriptionId*, *directoryId* and *secret* fields.
             * For GCP scan targets, provide a *projectId* field
             * For DOMAIN scan targets, provide a URL in the *domain* field
-        :param schedule: schedule in cron format
+        :param schedule: schedule as a string or enum version of the scan frequency
         :return: a dict representing the newly created scan target
         """
         validate_class(kind, ScanTargetKind)
         validate_class(name, str)
-        validate_class(schedule, str)
 
         if kind == ScanTargetKind.AWS:
             validate_class(credential, ScanTargetAWS)
@@ -754,7 +800,7 @@ class Client:
             "name": name,
             "kind": kind,
             "credential": credential,
-            "schedule": schedule
+            "schedule": ScanTargetSchedule.from_value(schedule).value
         }
         return self._request("POST", f"/organizations/{validate_uuid(organization_id)}/scantargets",
                              body=body).json()
@@ -772,7 +818,7 @@ class Client:
                              f"{validate_uuid(scan_target_id)}").json()
 
     def update_organization_scan_target(self, organization_id: Union[UUID, str], scan_target_id: Union[UUID, str],
-                                        name: str, schedule: str) -> Dict:
+                                        name: str, schedule: Union[str, ScanTargetSchedule]) -> Dict:
         """
         Update scan target of organization.
         <https://api.zanshin.tenchisecurity.com/#operation/editOrganizationScanTargetById>
@@ -785,7 +831,7 @@ class Client:
 
         body = {
             "name": name,
-            "schedule": schedule,
+            "schedule": ScanTargetSchedule.from_value(schedule).value,
         }
 
         return self._request("PUT",
@@ -1536,7 +1582,8 @@ class Client:
     def onboard_scan_target(self, region: str, organization_id: Union[UUID, str], kind: ScanTargetKind, name: str,
                             credential: Union[ScanTargetAWS, ScanTargetAZURE, ScanTargetGCP, ScanTargetHUAWEI,
                                               ScanTargetDOMAIN], boto3_session: any = None,
-                            boto3_profile: str = "default", schedule: str = "0 0 * * *") -> Dict:
+                            boto3_profile: str = "default",
+                            schedule: Union[str, ScanTargetSchedule] = ScanTargetSchedule.TWENTY_FOUR_HOURS) -> Dict:
         """
         Currently supports only AWS Scan Targets.
         For AWS Scan Target:
@@ -1551,7 +1598,7 @@ class Client:
             * For GCP scan targets, provide a *projectId* field.
             * For DOMAIN scan targets, provide a URL in the *domain* field.
 
-        :param schedule: schedule in cron format.
+        :param schedule: schedule in string or enum format.
         :param boto3_profile: boto3 profile name used for CloudFormation Deployment. If none, uses \"default\" profile.
         :param boto3_session: boto3 session used for CloudFormation Deployment. If informed, will ignore boto3_profile.
         :return: JSON object containing newly created scan target .

--- a/zanshinsdk/test_client.py
+++ b/zanshinsdk/test_client.py
@@ -2538,3 +2538,4 @@ class TestScanTargetSchedule(unittest.TestCase):
         self.assertRaises(TypeError, zanshinsdk.ScanTargetSchedule.from_value, 1)
         self.assertRaises(TypeError, zanshinsdk.ScanTargetSchedule.from_value, 1.0)
         self.assertRaises(ValueError, zanshinsdk.ScanTargetSchedule.from_value, "foo")
+        self.assertRaises(ValueError, zanshinsdk.ScanTargetSchedule.from_value, '0 */8 * * *')

--- a/zanshinsdk/test_client.py
+++ b/zanshinsdk/test_client.py
@@ -821,7 +821,7 @@ class TestClient(unittest.TestCase):
         kind = zanshinsdk.ScanTargetKind.AWS
         name = "ScanTargetTest"
         credential = zanshinsdk.ScanTargetAWS("123456")
-        schedule = "0 0 * * *"
+        schedule = "24h"
 
         self.sdk.create_organization_scan_target(organization_id, kind, name, credential, schedule)
 
@@ -835,7 +835,7 @@ class TestClient(unittest.TestCase):
         kind = zanshinsdk.ScanTargetKind.AZURE
         name = "ScanTargetTest"
         credential = zanshinsdk.ScanTargetAZURE("1234567890", "0123456789", "2345678901", "SECRET")
-        schedule = "0 0 * * *"
+        schedule = "24h"
 
         self.sdk.create_organization_scan_target(organization_id, kind, name, credential, schedule)
 
@@ -849,7 +849,7 @@ class TestClient(unittest.TestCase):
         kind = zanshinsdk.ScanTargetKind.GCP
         name = "ScanTargetTest"
         credential = zanshinsdk.ScanTargetGCP("123456")
-        schedule = "0 0 * * *"
+        schedule = "24h"
 
         self.sdk.create_organization_scan_target(organization_id, kind, name, credential, schedule)
 
@@ -863,7 +863,7 @@ class TestClient(unittest.TestCase):
         kind = zanshinsdk.ScanTargetKind.HUAWEI
         name = "ScanTargetTest"
         credential = zanshinsdk.ScanTargetHUAWEI("123456")
-        schedule = "0 0 * * *"
+        schedule = "24h"
 
         self.sdk.create_organization_scan_target(organization_id, kind, name, credential, schedule)
 
@@ -877,7 +877,7 @@ class TestClient(unittest.TestCase):
         kind = zanshinsdk.ScanTargetKind.DOMAIN
         name = "ScanTargetTest"
         credential = zanshinsdk.ScanTargetDOMAIN("domain.com")
-        schedule = "0 0 * * *"
+        schedule = "24h"
 
         self.sdk.create_organization_scan_target(organization_id, kind, name, credential, schedule)
 
@@ -900,7 +900,7 @@ class TestClient(unittest.TestCase):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         scan_target_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
         name = "ScanTargetTest"
-        schedule = "0 0 * * *"
+        schedule = "24h"
 
         self.sdk.update_organization_scan_target(organization_id, scan_target_id, name, schedule)
 
@@ -2358,7 +2358,7 @@ class TestClient(unittest.TestCase):
         kind = zanshinsdk.ScanTargetKind.AWS
         name = "OnboardTesting-it"
         credential = zanshinsdk.ScanTargetAWS(aws_account_id)
-        schedule = "0 0 * * *"
+        schedule = "24h"
         region = "us-east-1"
         boto3_profile = 'foo'
 
@@ -2456,7 +2456,7 @@ class TestClient(unittest.TestCase):
         kind = zanshinsdk.ScanTargetKind.AWS
         name = "OnboardTesting-it"
         credential = zanshinsdk.ScanTargetAWS(aws_account_id)
-        schedule = "0 0 * * *"
+        schedule = "24h"
         region = "us-east-1"
 
         boto3_session = boto3.Session(
@@ -2518,3 +2518,23 @@ class TestClient(unittest.TestCase):
         cf_stacks = cloudformation.describe_stacks(StackName=zanshin_cloudformation_stack_name)
         for cf_stack in cf_stacks['Stacks']:
             cloudformation.delete_stack(StackName=cf_stack['StackName'])
+
+class TestScanTargetSchedule(unittest.TestCase):
+    def test_from_value(self):
+        """
+        Tests the initialization of a new scan target schedule instance using the new enum class, its string equivalent
+        and the old cron-style strings.
+        """
+        for k,v in zanshinsdk.ScanTargetSchedule.__members__.items():
+            self.assertEqual(zanshinsdk.ScanTargetSchedule.from_value(v.value), v)
+            self.assertEqual(zanshinsdk.ScanTargetSchedule.from_value(v), v)
+
+        self.assertEqual(zanshinsdk.ScanTargetSchedule.from_value('0 * * * *'), zanshinsdk.ScanTargetSchedule.ONE_HOUR)
+        self.assertEqual(zanshinsdk.ScanTargetSchedule.from_value('0 */6 * * *'), zanshinsdk.ScanTargetSchedule.SIX_HOURS)
+        self.assertEqual(zanshinsdk.ScanTargetSchedule.from_value('0 */12 * * *'), zanshinsdk.ScanTargetSchedule.TWELVE_HOURS)
+        self.assertEqual(zanshinsdk.ScanTargetSchedule.from_value('0 0 * * *'), zanshinsdk.ScanTargetSchedule.TWENTY_FOUR_HOURS)
+        self.assertEqual(zanshinsdk.ScanTargetSchedule.from_value('0 0 * * 0'), zanshinsdk.ScanTargetSchedule.SEVEN_DAYS)
+
+        self.assertRaises(TypeError, zanshinsdk.ScanTargetSchedule.from_value, 1)
+        self.assertRaises(TypeError, zanshinsdk.ScanTargetSchedule.from_value, 1.0)
+        self.assertRaises(ValueError, zanshinsdk.ScanTargetSchedule.from_value, "foo")


### PR DESCRIPTION
* Creates a new enum called ScanTargetSchedule with the new possible values for scan target scan frequencies.
* Update existing client methods to accept either a string or the new enum format, performing proper input validation.
* Write tests to ensure validation and conversion of the old-style cron job format strings into the new values is working properly.
* Fixes existing tests.

Fixes #59 

Tested locally with unit tests.