### PR TITLE
fix force param on /scan endpoint

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1646,6 +1646,8 @@ class Client:
 
         self.check_organization_scan_target(
             organization_id=organization_id, scan_target_id=new_scan_target_id)
+        self.start_organization_scan_target_scan(
+            organization_id=organization_id, scan_target_id=new_scan_target_id, force=True)
         return self.get_organization_scan_target(organization_id=organization_id, scan_target_id=new_scan_target_id)
 
     def _deploy_cloudformation_zanshin_service_role(self, boto3_session: object, region: str, new_scan_target_id: str,

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -856,12 +856,12 @@ class Client:
         :return: a boolean if success
         """
 
-        body = {
-            "force": force
+        params = {
+            "force": "true" if force else "false" # Http params are always strings
         }
         return self._request("POST",
                              f"/organizations/{validate_uuid(organization_id)}/scantargets/"
-                             f"{validate_uuid(scan_target_id)}/scan", body=body).json()
+                             f"{validate_uuid(scan_target_id)}/scan", params=params).json()
 
     def stop_organization_scan_target_scan(self, organization_id: Union[UUID, str],
                                            scan_target_id: Union[UUID, str]) -> bool:

--- a/zanshinsdk/test_client.py
+++ b/zanshinsdk/test_client.py
@@ -927,8 +927,8 @@ class TestClient(unittest.TestCase):
 
         self.sdk._request.assert_called_once_with(
             "POST", f"/organizations/{organization_id}/scantargets/{scan_target_id}/scan",
-            body={
-                "force": True
+            params={
+                "force": "true"
             }
         )
 


### PR DESCRIPTION
Fixes the way we're sending the force param to the API

tested
- Wrote unittests
- Manually