### PR TITLE
Adds search, order sort and timestamp to alert list

### DIFF
--- a/zanshinsdk/__init__.py
+++ b/zanshinsdk/__init__.py
@@ -1,5 +1,5 @@
 from zanshinsdk.client import Client, AlertState, AlertSeverity, ScanTargetKind, ScanTargetSchedule, Languages, \
-    ScanTargetAWS, ScanTargetAZURE, ScanTargetGCP, ScanTargetHUAWEI, ScanTargetDOMAIN, Roles, validate_uuid
+    AlertsOrderOpts, SortOpts, ScanTargetAWS, ScanTargetAZURE, ScanTargetGCP, ScanTargetHUAWEI, ScanTargetDOMAIN, Roles, validate_uuid
 from zanshinsdk.iterator import AbstractPersistentAlertsIterator, PersistenceEntry
 from zanshinsdk.alerts_history import FilePersistentAlertsIterator
 from zanshinsdk.following_alerts_history import FilePersistentFollowingAlertsIterator

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -48,6 +48,21 @@ class ScanTargetKind(str, Enum):
     ORACLE = "ORACLE"
 
 
+class AlertsOrderOpts(str, Enum):
+    SCAN_TARGET_ID = "scanTargetId"
+    RESOURCE = "resource"
+    RULE = "rule"
+    SEVERITY = "severity"
+    STATE = "state"
+    CREATED_AT = "createdAt"
+    UPDATED_AT = "updatedAt"
+
+
+class SortOpts(str, Enum):
+    ASC = "asc"
+    DESC = "desc"
+
+
 class ScanTargetSchedule(str, Enum):
     ONE_HOUR = '1h'
     SIX_HOURS = '6h'
@@ -120,8 +135,8 @@ class Roles(str, Enum):
 
 
 class Languages(str, Enum):
-    PTBR = "pt-BR"
-    ENUS = "en-US"
+    PT_BR = "pt-BR"
+    EN_US = "en-US"
 
 
 class Client:
@@ -320,6 +335,9 @@ class Client:
         :param body: request body to pass along to httpx.Client.request
         :return: the requests.Response object returned by httpx.Client.request
         """
+
+        self._logger.debug("Requesting body=%s", body)
+
         response = self._client.request(method=method, url=self.api_url + path, params=params, json=body)
 
         if response.request.content:
@@ -934,7 +952,10 @@ class Client:
                          created_at_start: Optional[str] = None,
                          created_at_end: Optional[str] = None,
                          updated_at_start: Optional[str] = None,
-                         updated_at_end: Optional[str] = None) -> Dict:
+                         updated_at_end: Optional[str] = None,
+                         search: Optional[str] = None,
+                         order: Optional[str] = None,
+                         sort: Optional[str] = None) -> Dict:
         """
         Internal method to retrieve a single page of alerts from an organization
         :param organization_id: the ID of the organization
@@ -959,6 +980,14 @@ class Client:
             "page": page,
             "pageSize": page_size
         }
+        if search:
+            body["search"] = search
+        if order:
+            validate_class(order, AlertsOrderOpts)
+            body["order"] = order
+        if sort:
+            validate_class(sort, SortOpts)
+            body["sort"] = sort
         if scan_target_ids:
             if isinstance(scan_target_ids, str):
                 scan_target_ids = [scan_target_ids]
@@ -979,14 +1008,15 @@ class Client:
         if language:
             validate_class(language, Languages)
             body["lang"] = language
+        # TODO: Validate these dates.
         if created_at_start:
-            body["CreatedAtStart"] = created_at_start
+            body["createdAtStart"] = created_at_start
         if created_at_end:
-            body["CreatedAtEnd"] = created_at_end
+            body["createdAtEnd"] = created_at_end
         if updated_at_start:
-            body["UpdatedAtStart"] = updated_at_start
+            body["updatedAtStart"] = updated_at_start
         if updated_at_end:
-            body["UpdatedAtEnd"] = updated_at_end
+            body["updatedAtEnd"] = updated_at_end
 
         return self._request("POST", "/alerts", body=body).json()
 
@@ -1000,7 +1030,10 @@ class Client:
                     created_at_start: Optional[str] = None,
                     created_at_end: Optional[str] = None,
                     updated_at_start: Optional[str] = None,
-                    updated_at_end: Optional[str] = None) -> Iterator[Dict]:
+                    updated_at_end: Optional[str] = None,
+                    search: Optional[str] = None,
+                    order: Optional[str] = None,
+                    sort: Optional[str] = None) -> Iterator[Dict]:
         """
         Iterates over the alerts of an organization by loading them, transparently paginating on the API
         <https://api.zanshin.tenchisecurity.com/#operation/listAllAlert>
@@ -1015,19 +1048,23 @@ class Client:
         :param created_at_end: Search alerts by creation date - less or equals than
         :param updated_at_start: Search alerts by update date - greater or equals than
         :param updated_at_end: Search alerts by update date - less or equals than
+        :param search: Search string to find in alerts
+        :param order: Sort order to user "asc" or "desc"
+        :param sort: Sort by field - one of {"scanTargetId", "resource", "rule", "severity", "state", "createdAt", "updatedAt"}
         :return: an iterator over the JSON decoded alerts
         """
         page = self._get_alerts_page(organization_id, scan_target_ids, rule, states, severities, page=1,
                                      page_size=page_size, language=language, created_at_start=created_at_start,
                                      created_at_end=created_at_end, updated_at_start=updated_at_start,
-                                     updated_at_end=updated_at_end)
+                                     updated_at_end=updated_at_end, search=search, order=order, sort=sort)
         yield from page.get("data", [])
         for page_number in range(2, int(ceil(page.get("total", 0) / float(page_size))) + 1):
             page = self._get_alerts_page(organization_id, scan_target_ids, rule, states, severities,
                                          page=page_number, page_size=page_size, language=language,
                                          created_at_start=created_at_start,
                                          created_at_end=created_at_end, updated_at_start=updated_at_start,
-                                         updated_at_end=updated_at_end)
+                                         updated_at_end=updated_at_end,
+                                         search=search, order=order, sort=sort)
             yield from page.get("data", [])
 
     def _get_following_alerts_page(self, organization_id: Union[UUID, str],

--- a/zanshinsdk/test_client.py
+++ b/zanshinsdk/test_client.py
@@ -1060,17 +1060,24 @@ class TestClient(unittest.TestCase):
         page = 1
         page_size = 100
         rule = "rule"
-        language = zanshinsdk.Languages.ENUS
+        language = zanshinsdk.Languages.EN_US
+        # TODO: use valid dates
         created_at_start = "created_at_start"
         created_at_end = "created_at_end"
         updated_at_start = "updated_at_start"
         updated_at_end = "updated_at_end"
+        search = "search"
+        sort = zanshinsdk.SortOpts.ASC
+        order = zanshinsdk.AlertsOrderOpts.SEVERITY
 
         self.sdk._get_alerts_page(organization_id,
                                   page=page,
                                   page_size=page_size,
                                   rule=rule,
                                   language=language,
+                                  search=search,
+                                  order=order,
+                                  sort=sort,
                                   created_at_start=created_at_start,
                                   created_at_end=created_at_end,
                                   updated_at_start=updated_at_start,
@@ -1084,10 +1091,13 @@ class TestClient(unittest.TestCase):
                 "pageSize": page_size,
                 "rule": rule,
                 "lang": language,
-                "CreatedAtStart": created_at_start,
-                "CreatedAtEnd": created_at_end,
-                "UpdatedAtStart": updated_at_start,
-                "UpdatedAtEnd": updated_at_end
+                "search": search,
+                "order": order,
+                "sort": sort,
+                "createdAtStart": created_at_start,
+                "createdAtEnd": created_at_end,
+                "updatedAtStart": updated_at_start,
+                "updatedAtEnd": updated_at_end
             }
         )
 
@@ -1218,9 +1228,11 @@ class TestClient(unittest.TestCase):
 
         self.sdk._get_alerts_page.assert_has_calls([
             call(organization_id, None, None, None, None, page=page, page_size=page_size, language=None,
-                 created_at_start=None, created_at_end=None, updated_at_start=None, updated_at_end=None),
+                search=None, order=None, sort=None,
+                created_at_start=None, created_at_end=None, updated_at_start=None, updated_at_end=None),
             call(organization_id, None, None, None, None, page=page + 1, page_size=page_size, language=None,
-                 created_at_start=None, created_at_end=None, updated_at_start=None, updated_at_end=None)
+                search=None, order=None, sort=None,
+                created_at_start=None, created_at_end=None, updated_at_start=None, updated_at_end=None)
         ])
 
     def test_get_following_alerts_page(self):
@@ -1228,7 +1240,7 @@ class TestClient(unittest.TestCase):
         page = 1
         page_size = 100
         rule = "rule"
-        language = zanshinsdk.Languages.ENUS
+        language = zanshinsdk.Languages.EN_US
         created_at_start = "created_at_start"
         created_at_end = "created_at_end"
         updated_at_start = "updated_at_start"
@@ -1400,7 +1412,7 @@ class TestClient(unittest.TestCase):
     def test_get_alerts_history_page(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         page_size = 100
-        language = zanshinsdk.Languages.ENUS
+        language = zanshinsdk.Languages.EN_US
         cursor = "12345678"
 
         self.sdk._get_alerts_history_page(organization_id,
@@ -1477,7 +1489,7 @@ class TestClient(unittest.TestCase):
     def test_get_alerts_following_history_page(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         page_size = 100
-        language = zanshinsdk.Languages.ENUS
+        language = zanshinsdk.Languages.EN_US
         cursor = "12345678"
 
         self.sdk._get_alerts_following_history_page(organization_id,


### PR DESCRIPTION
Serveral endpoints have the ability to search and limit the range of alerts/rules returned.
In this PR we add search, order, sort and timestamp filtering to `iter_alerts` method of the SDK client.

Tested: locally, manually.