### PR TITLE
check if the scan target kind is accepted

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1018,6 +1018,9 @@ class Client:
         """
         validate_class(kind, ScanTargetKind)
         validate_class(name, str)
+        if kind != "ORACLE":
+            raise ValueError(f"{repr(kind.value)} is not accepted. 'ORACLE' is expected")
+
 
         body = {
             "name": name,

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1018,7 +1018,7 @@ class Client:
         """
         validate_class(kind, ScanTargetKind)
         validate_class(name, str)
-        if kind != "ORACLE":
+        if kind != ScanTargetKind.ORACLE:
             raise ValueError(f"{repr(kind.value)} is not accepted. 'ORACLE' is expected")
 
 

--- a/zanshinsdk/test_client.py
+++ b/zanshinsdk/test_client.py
@@ -1149,10 +1149,13 @@ class TestClient(unittest.TestCase):
 
     def test_create_scan_target_group(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        kind = zanshinsdk.ScanTargetKind.AWS
+        kind = zanshinsdk.ScanTargetKind.ORACLE
         name = "ScanTargetTest"
 
         self.sdk.create_scan_target_group(organization_id, kind, name)
+
+        with self.assertRaises(ValueError):
+            self.sdk.create_scan_target_group(organization_id, zanshinsdk.ScanTargetKind.AWS, name)
 
         self.sdk._request.assert_called_once_with(
             "POST", f"/organizations/{organization_id}/scantargetgroups",


### PR DESCRIPTION
Since only ORACLE kind is accepted currently, adds a ValueError return if other kind is given