### PR TITLE
feat: add oauth method to scan target group

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1110,11 +1110,10 @@ class Client:
     # Scan Target OAuth
     ###################################################
 
-    def get_kind_oauth_link(
+    def get_scan_target_oauth_link(
         self,
         organization_id: Union[UUID, str],
         scan_target_id: Union[UUID, str],
-        kind: Union[ScanTargetKind, OAuthTargetKind],
     ) -> Dict:
         """
         Retrieve a link to authorize zanshin to read info from their target.
@@ -1129,19 +1128,31 @@ class Client:
             * SALESFORCE
         :return: a dict with the link
         """
-        if kind.value not in [member.value for member in OAuthTargetKind]:
-            raise ValueError(f"{repr(kind.value)} is not eligible for OAuth link")
-
-        scan_type = (
-            "scanTargetGroupId"
-            if kind in [ScanTargetKind.BITBUCKET, ScanTargetKind.GITLAB]
-            else "scanTargetId"
-        )
-
         path = (
             f"/oauth/link"
             f"?organizationId={validate_uuid(organization_id)}"
-            f"&{scan_type}={validate_uuid(scan_target_id)}"
+            f"&scanTargetId={validate_uuid(scan_target_id)}"
+        )
+
+        return self._request("GET", path).json()
+    
+    def get_scan_target_group_oauth_link(
+            self,
+            organization_id: Union[UUID, str],
+            scan_target_group_id: Union[UUID, str],
+    ):
+        """
+        Retrieve a link to authorize zanshin to read info from their target group.
+
+        Mandatory for scan target groups of kind:
+            * BITBUCKET
+            * GITLAB
+        :return: a dict with the link
+        """
+        path = (
+            f"/oauth/link"
+            f"?organizationId={validate_uuid(organization_id)}"
+            f"&scanTargetGroupId={validate_uuid(scan_target_group_id)}"
         )
 
         return self._request("GET", path).json()

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1135,11 +1135,11 @@ class Client:
         )
 
         return self._request("GET", path).json()
-    
+
     def get_scan_target_group_oauth_link(
-            self,
-            organization_id: Union[UUID, str],
-            scan_target_group_id: Union[UUID, str],
+        self,
+        organization_id: Union[UUID, str],
+        scan_target_group_id: Union[UUID, str],
     ):
         """
         Retrieve a link to authorize zanshin to read info from their target group.

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1031,26 +1031,24 @@ class TestClient(unittest.TestCase):
             f"/organizations/{organization_id}/scantargets/{scan_target_id}/check",
         )
 
-    def test_get_kind_oauth_link_should_call_api_with_scan_target_id(self):
+    def test_get_scan_target_group_oauth_link_should_call_apiß(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        scan_target_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
-        kind = zanshinsdk.ScanTargetKind.GITLAB
+        scan_target_group_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
 
-        self.sdk.get_kind_oauth_link(organization_id, scan_target_id, kind)
+        self.sdk.get_scan_target_group_oauth_link(organization_id, scan_target_group_id)
 
         self.sdk._request.assert_called_once_with(
             "GET",
             f"/oauth/link?"
             f"organizationId={organization_id}"
-            f"&scanTargetGroupId={scan_target_id}",
+            f"&scanTargetGroupId={scan_target_group_id}",
         )
 
-    def test_get_kind_oauth_link_should_call_api_with_scan_target_group_id(self):
+    def test_get_scan_target_oauth_link_should_call_api_with_scan_target_group_id(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         scan_target_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
-        kind = zanshinsdk.ScanTargetKind.JIRA
 
-        self.sdk.get_kind_oauth_link(organization_id, scan_target_id, kind)
+        self.sdk.get_scan_target_oauth_link(organization_id, scan_target_id)
 
         self.sdk._request.assert_called_once_with(
             "GET",
@@ -1058,14 +1056,6 @@ class TestClient(unittest.TestCase):
             f"organizationId={organization_id}"
             f"&scanTargetId={scan_target_id}",
         )
-
-    def test_get_kind_oauth_link_should_raise_exception_with_invalid_kind(self):
-        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        scan_target_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
-        kind = zanshinsdk.ScanTargetKind.AWS
-
-        with self.assertRaises(ValueError):
-            self.sdk.get_kind_oauth_link(organization_id, scan_target_id, kind)
 
     def test_get_gworkspace_oauth_link(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"


### PR DESCRIPTION
Splitting the get oauth method in two separated methods, one for scan_target_id and the other for scan_target_group_id.