### PR TITLE
Remove push trigger from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,7 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - 'main'
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   zanshinsdk_jobs:


### PR DESCRIPTION
Removed the  push trigger from CI because already running on Pull Requests, when run from push on main is the same test.