### PR TITLE
add BaseAlertFilter support to trouped alerts commands

### DIFF
--- a/zanshinsdk/__init__.py
+++ b/zanshinsdk/__init__.py
@@ -7,6 +7,7 @@ from zanshinsdk.client import (
     AlertsOrderOpts,
     AlertState,
     Client,
+    GroupedAlertOrderOpts,
     Languages,
     Roles,
     ScanTargetAWS,

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -50,6 +50,7 @@ from zanshinsdk.common.targets import (
     ScanTargetZENDESK,
 )
 from zanshinsdk.common.validators import (
+    validate_base_alert_filter,
     validate_class,
     validate_date,
     validate_int,
@@ -2128,8 +2129,22 @@ class Client:
         following_ids: Optional[Iterable[Union[UUID, str]]] = None,
         following_tags: Optional[Iterable[str]] = None,
         include_empty_following_tags: Optional[bool] = None,
+        rules: Optional[Iterable[str]] = None,
+        states: Optional[Iterable[AlertState]] = None,
+        severities: Optional[Iterable[AlertSeverity]] = None,
+        lang: Optional[Languages] = None,
+        opened_at_start: Optional[str] = None,
+        opened_at_end: Optional[str] = None,
+        resolved_at_start: Optional[str] = None,
+        resolved_at_end: Optional[str] = None,
+        created_at_start: Optional[str] = None,
+        created_at_end: Optional[str] = None,
+        updated_at_start: Optional[str] = None,
+        updated_at_end: Optional[str] = None,
+        search: Optional[str] = None,
         cursor: Optional[str] = None,
         order: Optional[AlertsOrderOpts] = None,
+        sort: Optional[SortOpts] = None,
     ) -> Dict:
         """
         Internal method to retrieve a single page of alerts from organizations being followed
@@ -2137,18 +2152,46 @@ class Client:
         :param following_ids: optional list of scan target IDs to list alerts from, defaults to all
         :param following_tags: optional boolean to include followings without tags
         :param include_empty_following_tags: optional boolean to include followings without tags
+        :param rules: list of rules to filter alerts, not passing the field will fetch all
+        :param states: optional list of states to filter returned alerts, defaults to all
+        :param severities: optional list of severities to filter returned alerts, defaults to all
+        :param lang: language the rule will be returned. Ignored when historical is enabled
+        :param opened_at_start: Search alerts by opened date - greater or equals than
+        :param opened_at_end: Search alerts by opened date - less or equals than
+        :param resolved_at_start: Search alerts by resolved date - greater or equals than
+        :param resolved_at_end: Search alerts by resolved date - less or equals than
+        :param created_at_start: Search alerts by creation date - greater or equals than
+        :param created_at_end: Search alerts by creation date - less or equals than
+        :param updated_at_start: Search alerts by update date - greater or equals than
+        :param updated_at_end: Search alerts by update date - less or equals than
         :param cursor: Cursor of the last alert consumed, when this value is passed, subsequent alert histories will be returned.
         :param order: Sort order to use (ascending or descending)
+        :param cursor: Cursor of the last alert consumed, when this value is passed, subsequent alert histories will be returned.
+        :param sort: Which field to sort on
         :return: the decoded JSON response from the API
         """
-        body = {}
+        body = validate_base_alert_filter(
+            body={},
+            rules=rules,
+            states=states,
+            severities=severities,
+            search=search,
+            lang=lang,
+            opened_at_start=opened_at_start,
+            opened_at_end=opened_at_end,
+            resolved_at_start=resolved_at_start,
+            resolved_at_end=resolved_at_end,
+            created_at_start=created_at_start,
+            created_at_end=created_at_end,
+            updated_at_start=updated_at_start,
+            updated_at_end=updated_at_end,
+            order=order,
+            sort=sort,
+        )
         params = {}
         if cursor:
             validate_class(cursor, str)
             params["cursor"] = cursor
-        if order:
-            validate_class(order, AlertsOrderOpts)
-            body["order"] = order.value
         if following_ids:
             if isinstance(following_ids, str):
                 following_ids = [following_ids]
@@ -2175,8 +2218,22 @@ class Client:
         following_ids: Optional[Iterable[Union[UUID, str]]] = None,
         following_tags: Optional[Iterable[str]] = None,
         include_empty_following_tags: Optional[bool] = None,
+        rules: Optional[Iterable[str]] = None,
+        states: Optional[Iterable[AlertState]] = None,
+        severities: Optional[Iterable[AlertSeverity]] = None,
+        lang: Optional[Languages] = None,
+        opened_at_start: Optional[str] = None,
+        opened_at_end: Optional[str] = None,
+        resolved_at_start: Optional[str] = None,
+        resolved_at_end: Optional[str] = None,
+        created_at_start: Optional[str] = None,
+        created_at_end: Optional[str] = None,
+        updated_at_start: Optional[str] = None,
+        updated_at_end: Optional[str] = None,
+        search: Optional[str] = None,
         cursor: Optional[str] = None,
         order: Optional[AlertsOrderOpts] = None,
+        sort: Optional[SortOpts] = None,
     ) -> Iterator[Dict]:
         """
         Iterates over the grouped following alerts from organizations being followed by transparently paginating on the API.
@@ -2184,8 +2241,22 @@ class Client:
         :param following_ids: optional list of scan target IDs to list alerts from, defaults to all
         :param following_tags: optional boolean to include followings without tags
         :param include_empty_following_tags: optional boolean to include followings without tags
+        :param rules: list of rules to filter alerts, not passing the field will fetch all
+        :param states: optional list of states to filter returned alerts, defaults to all
+        :param severities: optional list of severities to filter returned alerts, defaults to all
+        :param lang: language the rule will be returned. Ignored when historical is enabled
+        :param opened_at_start: Search alerts by opened date - greater or equals than
+        :param opened_at_end: Search alerts by opened date - less or equals than
+        :param resolved_at_start: Search alerts by resolved date - greater or equals than
+        :param resolved_at_end: Search alerts by resolved date - less or equals than
+        :param created_at_start: Search alerts by creation date - greater or equals than
+        :param created_at_end: Search alerts by creation date - less or equals than
+        :param updated_at_start: Search alerts by update date - greater or equals than
+        :param updated_at_end: Search alerts by update date - less or equals than
         :param cursor: Cursor of the last alert consumed, when this value is passed, subsequent alert histories will be returned.
         :param order: Sort order to use (ascending or descending)
+        :param cursor: Cursor of the last alert consumed, when this value is passed, subsequent alert histories will be returned.
+        :param sort: Which field to sort on
         """
 
         page = self._get_grouped_following_alerts_page(
@@ -2195,6 +2266,20 @@ class Client:
             include_empty_following_tags=include_empty_following_tags,
             cursor=cursor,
             order=order,
+            rules=rules,
+            states=states,
+            severities=severities,
+            lang=lang,
+            opened_at_start=opened_at_start,
+            opened_at_end=opened_at_end,
+            resolved_at_start=resolved_at_start,
+            resolved_at_end=resolved_at_end,
+            created_at_start=created_at_start,
+            created_at_end=created_at_end,
+            updated_at_start=updated_at_start,
+            updated_at_end=updated_at_end,
+            search=search,
+            sort=sort,
         )
         yield from page.get("data", [])
         while page.get("cursor"):
@@ -2205,6 +2290,20 @@ class Client:
                 include_empty_following_tags=include_empty_following_tags,
                 cursor=page.get("cursor"),
                 order=order,
+                rules=rules,
+                states=states,
+                severities=severities,
+                lang=lang,
+                opened_at_start=opened_at_start,
+                opened_at_end=opened_at_end,
+                resolved_at_start=resolved_at_start,
+                resolved_at_end=resolved_at_end,
+                created_at_start=created_at_start,
+                created_at_end=created_at_end,
+                updated_at_start=updated_at_start,
+                updated_at_end=updated_at_end,
+                search=search,
+                sort=sort,
             )
             yield from page.get("data", [])
 

--- a/zanshinsdk/common/enums.py
+++ b/zanshinsdk/common/enums.py
@@ -65,6 +65,12 @@ class AlertsOrderOpts(str, Enum):
     UPDATED_AT = "updatedAt"
 
 
+class GroupedAlertOrderOpts(str, Enum):
+    SEVERITY = "severity"
+    RULE = "rule"
+    TOTAL = "total"
+
+
 class SortOpts(str, Enum):
     ASC = "ASC"
     DESC = "DESC"

--- a/zanshinsdk/common/validators.py
+++ b/zanshinsdk/common/validators.py
@@ -1,7 +1,14 @@
+from copy import deepcopy
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional, Union, Iterable
 from uuid import UUID
-
+from zanshinsdk.common.enums import (
+    AlertSeverity,
+    AlertsOrderOpts,
+    AlertState,
+    Languages,
+    SortOpts,
+)
 
 def validate_int(
     value, min_value=None, max_value=None, required=False
@@ -64,3 +71,70 @@ def validate_date(
         )
 
     raise TypeError(f"{repr(date)} is not a valid date type")
+
+
+def validate_base_alert_filter(
+    body: dict,
+    rules: Optional[Iterable[str]] = None,
+    states: Optional[Iterable[AlertState]] = None,
+    severities: Optional[Iterable[AlertSeverity]] = None,
+    search: Optional[str] = None,
+    lang: Optional[Languages] = None,
+    opened_at_start: Optional[str] = None,
+    opened_at_end: Optional[str] = None,
+    resolved_at_start: Optional[str] = None,
+    resolved_at_end: Optional[str] = None,
+    created_at_start: Optional[str] = None,
+    created_at_end: Optional[str] = None,
+    updated_at_start: Optional[str] = None,
+    updated_at_end: Optional[str] = None,
+    order: Optional[AlertsOrderOpts] = None,
+    sort: Optional[SortOpts] = None,
+) -> dict:
+    cloned_body = deepcopy(body)
+    if rules:
+        cloned_body["rules"] = [validate_class(rule, str) for rule in rules]
+    if states:
+        if isinstance(states, str) or isinstance(states, AlertState):
+            states = [states]
+        validate_class(states, Iterable)
+        cloned_body["states"] = [
+            validate_class(state, AlertState).value for state in states
+        ]
+    if severities:
+        if isinstance(severities, str):
+            severities = [severities]
+        validate_class(severities, Iterable)
+        cloned_body["severities"] = [
+            validate_class(severity, AlertSeverity).value for severity in severities
+        ]
+    if lang:
+        validate_class(lang, Languages)
+        cloned_body["lang"] = lang.value
+    if opened_at_start:
+        cloned_body["openedAtStart"] = validate_date(opened_at_start).isoformat()
+    if opened_at_end:
+        cloned_body["openedAtEnd"] = validate_date(opened_at_end).isoformat()
+    if resolved_at_start:
+        cloned_body["resolvedAtStart"] = validate_date(resolved_at_start).isoformat()
+    if resolved_at_end:
+        cloned_body["resolvedAtEnd"] = validate_date(resolved_at_end).isoformat()
+    if created_at_start:
+        cloned_body["createdAtStart"] = validate_date(created_at_start).isoformat()
+    if created_at_end:
+        cloned_body["createdAtEnd"] = validate_date(created_at_end).isoformat()
+    if updated_at_start:
+        cloned_body["updatedAtStart"] = validate_date(updated_at_start).isoformat()
+    if updated_at_end:
+        cloned_body["updatedAtEnd"] = validate_date(updated_at_end).isoformat()
+    if order:
+        validate_class(order, AlertsOrderOpts)
+        cloned_body["order"] = order.value
+    if search:
+        validate_class(search, str)
+        cloned_body["search"] = search
+    if sort:
+        validate_class(sort, SortOpts)
+        cloned_body["sort"] = sort.value
+    print(sort)
+    return cloned_body

--- a/zanshinsdk/common/validators.py
+++ b/zanshinsdk/common/validators.py
@@ -1,7 +1,8 @@
 from copy import deepcopy
 from datetime import datetime
-from typing import Optional, Union, Iterable
+from typing import Iterable, Optional, Union
 from uuid import UUID
+
 from zanshinsdk.common.enums import (
     AlertSeverity,
     AlertsOrderOpts,
@@ -9,6 +10,7 @@ from zanshinsdk.common.enums import (
     Languages,
     SortOpts,
 )
+
 
 def validate_int(
     value, min_value=None, max_value=None, required=False
@@ -136,5 +138,4 @@ def validate_base_alert_filter(
     if sort:
         validate_class(sort, SortOpts)
         cloned_body["sort"] = sort.value
-    print(sort)
     return cloned_body

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1797,205 +1797,55 @@ class TestClient(unittest.TestCase):
 
     def test_get_grouped_alerts_page(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        page = 1
-        page_size = 100
+        order = zanshinsdk.GroupedAlertOrderOpts.SEVERITY
+        page_size = 50
 
         self.sdk._get_grouped_alerts_page(
-            organization_id, page=page, page_size=page_size
+            organization_id, page_size=page_size, order=order
         )
 
         self.sdk._request.assert_called_once_with(
             "POST",
-            f"/alerts/rules",
-            body={
-                "organizationId": organization_id,
-                "page": page,
-                "pageSize": page_size,
-            },
-        )
-
-    def test_get_grouped_alerts_page_str_scan_target_ids(self):
-        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        page = 1
-        page_size = 100
-        scan_target_ids = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
-
-        self.sdk._get_grouped_alerts_page(
-            organization_id,
-            page=page,
-            page_size=page_size,
-            scan_target_ids=scan_target_ids,
-        )
-
-        self.sdk._request.assert_called_once_with(
-            "POST",
-            f"/alerts/rules",
-            body={
-                "organizationId": organization_id,
-                "page": page,
-                "pageSize": page_size,
-                "scanTargetIds": [scan_target_ids],
-            },
-        )
-
-    def test_get_grouped_alerts_page_iterable_scan_target_ids(self):
-        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        page = 1
-        page_size = 100
-        scan_target_ids = [
-            "e22f4225-43e9-4922-b6b8-8b0620bdb110",
-            "e22f4225-43e9-4922-b6b8-8b0620bdb112",
-        ]
-
-        self.sdk._get_grouped_alerts_page(
-            organization_id,
-            page=page,
-            page_size=page_size,
-            scan_target_ids=scan_target_ids,
-        )
-
-        self.sdk._request.assert_called_once_with(
-            "POST",
-            f"/alerts/rules",
-            body={
-                "organizationId": organization_id,
-                "page": page,
-                "pageSize": page_size,
-                "scanTargetIds": scan_target_ids,
-            },
-        )
-
-    def test_get_grouped_alerts_page_str_states(self):
-        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        page = 1
-        page_size = 100
-        states = zanshinsdk.AlertState.OPEN
-
-        self.sdk._get_grouped_alerts_page(
-            organization_id, page=page, page_size=page_size, states=states
-        )
-
-        self.sdk._request.assert_called_once_with(
-            "POST",
-            f"/alerts/rules",
-            body={
-                "organizationId": organization_id,
-                "page": page,
-                "pageSize": page_size,
-                "states": [states],
-            },
-        )
-
-    def test_get_grouped_alerts_page_iterable_states(self):
-        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        page = 1
-        page_size = 100
-        states = [zanshinsdk.AlertState.OPEN, zanshinsdk.AlertState.CLOSED]
-
-        self.sdk._get_grouped_alerts_page(
-            organization_id, page=page, page_size=page_size, states=states
-        )
-
-        self.sdk._request.assert_called_once_with(
-            "POST",
-            f"/alerts/rules",
-            body={
-                "organizationId": organization_id,
-                "page": page,
-                "pageSize": page_size,
-                "states": states,
-            },
-        )
-
-    def test_get_grouped_alerts_page_str_severities(self):
-        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        page = 1
-        page_size = 100
-        severities = zanshinsdk.AlertSeverity.CRITICAL
-
-        self.sdk._get_grouped_alerts_page(
-            organization_id, page=page, page_size=page_size, severities=severities
-        )
-
-        self.sdk._request.assert_called_once_with(
-            "POST",
-            f"/alerts/rules",
-            body={
-                "organizationId": organization_id,
-                "page": page,
-                "pageSize": page_size,
-                "severities": [severities],
-            },
-        )
-
-    def test_get_grouped_alerts_page_iterable_severities(self):
-        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        page = 1
-        page_size = 100
-        severities = [zanshinsdk.AlertSeverity.CRITICAL, zanshinsdk.AlertSeverity.HIGH]
-
-        self.sdk._get_grouped_alerts_page(
-            organization_id, page=page, page_size=page_size, severities=severities
-        )
-
-        self.sdk._request.assert_called_once_with(
-            "POST",
-            f"/alerts/rules",
-            body={
-                "organizationId": organization_id,
-                "page": page,
-                "pageSize": page_size,
-                "severities": severities,
-            },
+            f"/organizations/{organization_id}/alerts/rules",
+            body={"order": order},
+            params={"pageSize": page_size},
         )
 
     @patch("zanshinsdk.client.Client._get_grouped_alerts_page")
     def test_iter_grouped_alerts(self, request):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        page = 1
-        page_size = 1
-
-        request.return_value = {"data": [""], "total": 2}
-
+        request.return_value = {"data": [""], "cursor": None}
         self.sdk._get_grouped_alerts_page = request
-        iterator = self.sdk.iter_grouped_alerts(organization_id, page_size=page_size)
-
+        iterator = self.sdk.iter_grouped_alerts(organization_id)
         next(iterator)
-        next(iterator)
-
-        self.sdk._get_grouped_alerts_page.assert_has_calls(
-            [
-                call(
-                    organization_id,
-                    None,
-                    None,
-                    None,
-                    page=page,
-                    page_size=page_size,
-                    language=None,
-                    search=None,
-                    order=None,
-                    sort=None,
-                ),
-                call(
-                    organization_id,
-                    None,
-                    None,
-                    None,
-                    page=page + 1,
-                    page_size=page_size,
-                    language=None,
-                    search=None,
-                    order=None,
-                    sort=None,
-                ),
-            ]
+        self.sdk._get_grouped_alerts_page.assert_called_once_with(
+            organization_id,
+            scan_target_ids=None,
+            scan_tagert_tags=None,
+            include_empty_scan_target_tags=None,
+            cursor=None,
+            page_size=100,
+            order=None,
+            rules=None,
+            states=None,
+            severities=None,
+            lang=None,
+            opened_at_start=None,
+            opened_at_end=None,
+            resolved_at_start=None,
+            resolved_at_end=None,
+            created_at_start=None,
+            created_at_end=None,
+            updated_at_start=None,
+            updated_at_end=None,
+            search=None,
+            sort=None,
         )
 
     def test_get_grouped_following_alerts_page(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         following_ids = ["421cfe8a-1777-4000-a000-f836dfdfcfb8"]
-        order = zanshinsdk.AlertsOrderOpts.SEVERITY
+        order = zanshinsdk.GroupedAlertOrderOpts.SEVERITY
         following_tags = None
         include_empty_following_tags = None
         cursor = "eyJpZCI6IjAyYWQxOGU3LTY1ODUtNDAwMC1hMDAwLWY2YTQzMTFlYzI4NyJ9"
@@ -2016,7 +1866,8 @@ class TestClient(unittest.TestCase):
                 "followingIds": following_ids,
             },
             params={
-                "cursor": "eyJpZCI6IjAyYWQxOGU3LTY1ODUtNDAwMC1hMDAwLWY2YTQzMTFlYzI4NyJ9"
+                "cursor": "eyJpZCI6IjAyYWQxOGU3LTY1ODUtNDAwMC1hMDAwLWY2YTQzMTFlYzI4NyJ9",
+                "pageSize": 100,
             },
         )
 
@@ -2039,7 +1890,22 @@ class TestClient(unittest.TestCase):
             following_tags=None,
             include_empty_following_tags=None,
             cursor=None,
+            page_size=100,
             order=None,
+            rules=None,
+            states=None,
+            severities=None,
+            lang=None,
+            opened_at_start=None,
+            opened_at_end=None,
+            resolved_at_start=None,
+            resolved_at_end=None,
+            created_at_start=None,
+            created_at_end=None,
+            updated_at_start=None,
+            updated_at_end=None,
+            search=None,
+            sort=None,
         )
 
     def test_get_alert(self):
@@ -2184,7 +2050,7 @@ class TestClient(unittest.TestCase):
 
     def test__repr__(self):
         _response = (
-            f"Connection(api_url='https://api.zanshin.tenchisecurity.com', api_key='***pi_key', "
+            f"Connection(api_url='https://api.zanshin.tenchisecurity.com', api_key='***NG_ONE', "
             f"user_agent='Zanshin Python SDK v{zanshinsdk.version.__version__}', proxy_url='None')"
         )
         self.assertEqual(self.sdk.__repr__(), _response)

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -2050,7 +2050,7 @@ class TestClient(unittest.TestCase):
 
     def test__repr__(self):
         _response = (
-            f"Connection(api_url='https://api.zanshin.tenchisecurity.com', api_key='***NG_ONE', "
+            f"Connection(api_url='https://api.zanshin.tenchisecurity.com', api_key='***pi_key', "
             f"user_agent='Zanshin Python SDK v{zanshinsdk.version.__version__}', proxy_url='None')"
         )
         self.assertEqual(self.sdk.__repr__(), _response)


### PR DESCRIPTION
### Description

This PR enhances the grouped alerts commands by adding support for BaseAlertFilter, ensuring consistency with API capabilities.

### Changes:
- Added `BaseAlertFilter` validator.
- Applied validator to `iter_grouped_following_alerts`.
- Updated `iter_grouped_alerts` method to integrate the filter.

These changes allow for more flexible and precise filtering when iterating through grouped alerts. 🚀