### PR TITLE
add page size parameter to iter_following_alerts to improve pagination efficiency

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1659,6 +1659,7 @@ class Client:
         cursor: Optional[str] = None,
         order: Optional[AlertsOrderOpts] = None,
         sort: Optional[SortOpts] = None,
+        page_size: int = 100,
     ) -> Dict:
         """
         Internal method to retrieve a single page of alerts from organizations being followed
@@ -1683,8 +1684,9 @@ class Client:
         :param sort: Which field to sort on
         :return: a JSON decoded following alerts
         """
+        validate_int(page_size, min_value=1, required=True)
         body = {}
-        params = {}
+        params = {"size": page_size}
         if cursor:
             validate_class(cursor, str)
             params["cursor"] = cursor
@@ -1774,6 +1776,7 @@ class Client:
         cursor: Optional[str] = None,
         order: Optional[AlertsOrderOpts] = None,
         sort: Optional[SortOpts] = None,
+        page_size: int = 100,
     ) -> Iterator[Dict]:
         """
         Iterates over the following alerts from organizations being followed by transparently paginating on the API.
@@ -1796,6 +1799,7 @@ class Client:
         :param cursor: Cursor of the last alert consumed, when this value is passed, subsequent alert histories will be returned.
         :param order: Sort order to use based od alert order opts
         :param sort: Which field to sort on
+        :param page_size: Page size of alerts
         :return: an iterator over the JSON decoded alerts
         """
         page = self._get_following_alerts_page(
@@ -1819,6 +1823,7 @@ class Client:
             updated_at_end=updated_at_end,
             search=search,
             sort=sort,
+            page_size=page_size,
         )
         yield from page.get("data", [])
         while page.get("cursor"):
@@ -1843,6 +1848,7 @@ class Client:
                 updated_at_end=updated_at_end,
                 search=search,
                 sort=sort,
+                page_size=page_size,
             )
             yield from page.get("data", [])
 

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1569,7 +1569,8 @@ class TestClient(unittest.TestCase):
                 "openedAtStart": "2025-01-10T00:00:00",
             },
             params={
-                "cursor": "eyJpZCI6IjAyYWQxOGU3LTY1ODUtNDAwMC1hMDAwLWY2YTQzMTFlYzI4NyJ9"
+                "cursor": "eyJpZCI6IjAyYWQxOGU3LTY1ODUtNDAwMC1hMDAwLWY2YTQzMTFlYzI4NyJ9",
+                "size": 100,
             },
         )
 
@@ -1607,6 +1608,7 @@ class TestClient(unittest.TestCase):
             updated_at_end=None,
             search=None,
             sort=None,
+            page_size=100,
         )
 
     def test_get_alerts_history_page(self):


### PR DESCRIPTION
### Description

This PR adds support for a `page_size` parameter in the `iter_following_alerts` method, allowing more efficient pagination when retrieving alerts from followed organizations.

By enabling this parameter, we can reduce the number of API requests needed to fetch all alerts, especially when working with large datasets.

### Changes Introduced

- Added `page_size` parameter to `iter_following_alerts` and its internal pagination logic.
- Validated `page_size` input using existing utility functions.
- Updated the `_get_following_alerts_page` method to include the `size` parameter in API requests.
- Modified unit tests to verify that the page size is correctly passed in the request.

### Testing & Validation

1. Added unit tests to confirm `page_size` is included in the request parameters.
2. Verified that pagination works as expected and handles large alert sets correctly.

### Issue Reference

Closes #163 🚀
