### PR TITLE
Add pagination to alerts history

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -25,7 +25,6 @@ from zanshinsdk.common.enums import (
     Frequency,
     GroupedAlertOrderOpts,
     Languages,
-    OAuthTargetKind,
     Roles,
     ScanTargetGroupKind,
     ScanTargetKind,
@@ -506,7 +505,7 @@ class Client:
         :return: a dict representing the organization
         """
         body = {"name": name}
-        return self._request("POST", f"/organizations", body=body).json()
+        return self._request("POST", "/organizations", body=body).json()
 
     ###################################################
     # Organization Member
@@ -2911,7 +2910,7 @@ class Client:
             sts = boto3_session.client("sts")
             sts.get_caller_identity()
         except Exception as e:
-            self._logger.exception("boto3 session is invalid")
+            self._logger.exception(f"boto3 session is invalid: {e}")
             raise ValueError(
                 "boto3 session is invalid. Working boto3 session is required."
             )

--- a/zanshinsdk/tests/test_alerts_history.py
+++ b/zanshinsdk/tests/test_alerts_history.py
@@ -70,6 +70,6 @@ class TestAlertsHistoryIterator(unittest.TestCase):
 
         self.file_persistent.client._request.assert_called_once_with(
             "POST",
-            f"/alerts/history",
+            "/alerts/history",
             body={"organizationId": organization_id, "pageSize": 100, "cursor": cursor},
         )

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1920,19 +1920,6 @@ class TestClient(unittest.TestCase):
             f"/alerts/{alert_id}",
         )
 
-    def test_iter_alert_history(self):
-        alert_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-
-        try:
-            next(self.sdk.iter_alert_history(alert_id))
-        except StopIteration:
-            pass
-
-        self.sdk._request.assert_called_once_with(
-            "GET",
-            f"/alerts/{alert_id}/history",
-        )
-
     def test_update_alert(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         alert_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
@@ -2579,3 +2566,30 @@ class TestClient(unittest.TestCase):
             call(alert_id=alert_id, page_size=page_size, page=3),
         ]
         self.sdk._get_alert_comment_page.assert_has_calls(expected_calls)
+
+    @patch("zanshinsdk.client.Client._get_alert_history_page")
+    def test_iter_alert_history(self, request):
+        alert_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
+        page_size = 2
+        total_comments = 5
+
+        request.side_effect = [
+            {"data": ["history1", "history2"], "total": total_comments},
+            {"data": ["history3", "history4"]},
+            {"data": ["history5"]},
+        ]
+
+        self.sdk._get_alert_history_page = request
+        iterator = self.sdk.iter_alert_history(alert_id, page_size=page_size)
+        comments = list(iterator)
+
+        self.assertEqual(
+            comments, ["history1", "history2", "history3", "history4", "history5"]
+        )
+
+        expected_calls = [
+            call(alert_id=alert_id, page_size=page_size, page=1),
+            call(alert_id=alert_id, page_size=page_size, page=2),
+            call(alert_id=alert_id, page_size=page_size, page=3),
+        ]
+        self.sdk._get_alert_history_page.assert_has_calls(expected_calls)

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -27,8 +27,6 @@ class TestClient(unittest.TestCase):
 
         self.HAVE_BOTO3 = False
         try:
-            import boto3
-
             self.HAVE_BOTO3 = True
         except ModuleNotFoundError:
             pass
@@ -244,7 +242,7 @@ class TestClient(unittest.TestCase):
 
             client.api_url = None
         except Exception as e:
-            self.assertEqual(str(e), f"API URL cannot be null")
+            self.assertEqual(str(e), "API URL cannot be null")
 
     @patch("zanshinsdk.client.isfile")
     def test_get_api_key(self, mock_is_file):
@@ -548,7 +546,7 @@ class TestClient(unittest.TestCase):
         self.sdk.create_organization(name)
 
         self.sdk._request.assert_called_once_with(
-            "POST", f"/organizations", body={"name": name}
+            "POST", "/organizations", body={"name": name}
         )
 
     ###################################################
@@ -1623,7 +1621,7 @@ class TestClient(unittest.TestCase):
 
         self.sdk._request.assert_called_once_with(
             "POST",
-            f"/alerts/history",
+            "/alerts/history",
             body={
                 "organizationId": organization_id,
                 "pageSize": page_size,
@@ -1643,7 +1641,7 @@ class TestClient(unittest.TestCase):
 
         self.sdk._request.assert_called_once_with(
             "POST",
-            f"/alerts/history",
+            "/alerts/history",
             body={
                 "organizationId": organization_id,
                 "pageSize": page_size,
@@ -1665,7 +1663,7 @@ class TestClient(unittest.TestCase):
 
         self.sdk._request.assert_called_once_with(
             "POST",
-            f"/alerts/history",
+            "/alerts/history",
             body={
                 "organizationId": organization_id,
                 "pageSize": page_size,
@@ -1715,7 +1713,7 @@ class TestClient(unittest.TestCase):
 
         self.sdk._request.assert_called_once_with(
             "POST",
-            f"/alerts/history/following",
+            "/alerts/history/following",
             body={
                 "organizationId": organization_id,
                 "pageSize": page_size,
@@ -1735,7 +1733,7 @@ class TestClient(unittest.TestCase):
 
         self.sdk._request.assert_called_once_with(
             "POST",
-            f"/alerts/history/following",
+            "/alerts/history/following",
             body={
                 "organizationId": organization_id,
                 "pageSize": page_size,
@@ -1757,7 +1755,7 @@ class TestClient(unittest.TestCase):
 
         self.sdk._request.assert_called_once_with(
             "POST",
-            f"/alerts/history/following",
+            "/alerts/history/following",
             body={
                 "organizationId": organization_id,
                 "pageSize": page_size,
@@ -2044,7 +2042,7 @@ class TestClient(unittest.TestCase):
         try:
             zanshinsdk.client.validate_int(_int, required=True)
         except Exception as e:
-            self.assertEqual(str(e), f"required integer parameter missing")
+            self.assertEqual(str(e), "required integer parameter missing")
 
     def test_validate_int_not_int(self):
         _int = "NaN"

--- a/zanshinsdk/tests/test_following_alerts_history.py
+++ b/zanshinsdk/tests/test_following_alerts_history.py
@@ -70,6 +70,6 @@ class TestAlertsHistoryIterator(unittest.TestCase):
 
         self.file_persistent.client._request.assert_called_once_with(
             "POST",
-            f"/alerts/history/following",
+            "/alerts/history/following",
             body={"organizationId": organization_id, "pageSize": 100, "cursor": cursor},
         )


### PR DESCRIPTION
## Description

The `iter_alert_history` command currently does not have a page size parameter.

To improve efficiency and reduce the number of requests needed to fetch all alerts, a `pageSize` parameter should be added. This also maintains consistency with other paginated endpoints that follow the API's standard implementation pattern.

## Details

- **SDK Command:** `iter_alert_history`  
- **API URL:** `/organizations/:organizationId/alerts/:alertId/history`  
- **Modification Required:** Add page size parameter at command level and include it in the API request.
