### PR TITLE
add page size parameter to alert listing methods

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1480,7 +1480,7 @@ class Client:
         """
         validate_int(page_size, min_value=1, required=True)
         body = {}
-        params = {'size': page_size}
+        params = {"size": page_size}
         if cursor:
             validate_class(cursor, str)
             params["cursor"] = cursor

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1452,6 +1452,7 @@ class Client:
         cursor: Optional[str] = None,
         order: Optional[AlertsOrderOpts] = None,
         sort: Optional[SortOpts] = None,
+        page_size: Optional[int] = None,
     ) -> Dict:
         """
         Internal method to retrieve a single page of alerts from an organization
@@ -1477,8 +1478,9 @@ class Client:
         :return: a JSON decoded alerts
         :return:
         """
+        validate_int(page_size, min_value=1, required=True)
         body = {}
-        params = {}
+        params = {'size': page_size}
         if cursor:
             validate_class(cursor, str)
             params["cursor"] = cursor
@@ -1568,6 +1570,7 @@ class Client:
         cursor: Optional[str] = None,
         order: Optional[AlertsOrderOpts] = None,
         sort: Optional[SortOpts] = None,
+        page_size: Optional[int] = 1000,
     ) -> Iterator[Dict]:
         """
         Iterates over the alerts of an organization by loading them, transparently paginating on the API
@@ -1613,6 +1616,7 @@ class Client:
             updated_at_end=updated_at_end,
             search=search,
             sort=sort,
+            page_size=page_size,
         )
         yield from page.get("data", [])
         while page.get("cursor"):
@@ -1637,6 +1641,7 @@ class Client:
                 updated_at_end=updated_at_end,
                 search=search,
                 sort=sort,
+                page_size=page_size,
             )
             yield from page.get("data", [])
 

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1483,7 +1483,7 @@ class TestClient(unittest.TestCase):
             severities=severities,
             resolved_at_start=resolved_at_start,
             resolved_at_end=resolved_at_end,
-            page_size=1000
+            page_size=1000,
         )
 
         self.sdk._request.assert_called_once_with(
@@ -1498,7 +1498,7 @@ class TestClient(unittest.TestCase):
             },
             params={
                 "size": 1000,
-                "cursor": "eyJpZCI6IjAyYWQxOGU3LTY1ODUtNDAwMC1hMDAwLWY2YTQzMTFlYzI4NyJ9"
+                "cursor": "eyJpZCI6IjAyYWQxOGU3LTY1ODUtNDAwMC1hMDAwLWY2YTQzMTFlYzI4NyJ9",
             },
         )
 

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1483,6 +1483,7 @@ class TestClient(unittest.TestCase):
             severities=severities,
             resolved_at_start=resolved_at_start,
             resolved_at_end=resolved_at_end,
+            page_size=1000
         )
 
         self.sdk._request.assert_called_once_with(
@@ -1496,6 +1497,7 @@ class TestClient(unittest.TestCase):
                 "resolvedAtEnd": "2025-02-12T20:22:54.440101",
             },
             params={
+                "size": 1000,
                 "cursor": "eyJpZCI6IjAyYWQxOGU3LTY1ODUtNDAwMC1hMDAwLWY2YTQzMTFlYzI4NyJ9"
             },
         )
@@ -1535,6 +1537,7 @@ class TestClient(unittest.TestCase):
             updated_at_end=None,
             search=None,
             sort=None,
+            page_size=1000,
         )
 
     def test_get_following_alerts_page(self):


### PR DESCRIPTION
### Description

This PR adds support for specifying a custom `page_size` when listing alerts in the Zanshin SDK client. This enables greater control over pagination behavior and can help improve performance for large data fetches.

### Details

- Introduced an optional `page_size` parameter to:
  - `Client._get_organization_alerts_page`
  - `Client.iter_organization_alerts`
- The `page_size` value is validated (`min_value=1`, `required=True` in `_get_organization_alerts_page`)
- Adjusted internal API call to include the `size` query parameter
- Extended `test_client.py` to assert that the `size` parameter is passed correctly in alert queries

### Tested

- Added test case to validate `page_size` parameter usage in `iter_organization_alerts`
- Verified request body and params contain expected values
