### PR TITLE
add get alerts over time method

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -2801,6 +2801,37 @@ class Client:
             body=body,
         ).json()
 
+    def get_alerts_over_time(
+        self,
+        organization_id: Union[UUID, str],
+        following_ids: Optional[Iterable[Union[UUID, str]]] = None,
+        severities: Optional[Iterable[Union[AlertSeverity, str]]] = None,
+        dates: Optional[Iterable[str]] = None,
+    ) -> Dict:
+        """
+        Get scan target following summary.
+        <https://api.zanshin.tenchisecurity.com/#tag/Summaries/operation/alertFollowingResolvedOverTimeSummary>
+        :param organization_id: Organization that the requester belongs to, data will be fetched from this organization followings
+        :param following_ids: Organizations to filter following alerts from (FollowingIds), all ids must belong to following organizations. not passing the field will fetch from all
+        :param severities: Severities of the alerts to filter, not passing the field will fetch all.
+        :param dates: Dates to gather the data for (YYYY-MM-DD format), not passing the field will fetch the data for the current day. A maximum of 12 dates can be passed. Passing dates for which the system has no data will result in that item not being included in the response.``
+        :return: JSON object containing the summarized data on the trend of resolved alerts
+        """
+        body = {"organizationId": validate_uuid(organization_id)}
+        if following_ids:
+            body["followingIds"] = [
+                validate_uuid(following_id) for following_id in following_ids
+            ]
+        if severities:
+            body["severities"] = [
+                validate_class(severity, AlertSeverity).value for severity in severities
+            ]
+        if dates:
+            body["date"] = [validate_date(date) for date in dates]
+        return self._request(
+            "POST", "/alerts/summaries/following/resolvedovertime", body=body
+        ).json()
+
     ###################################################
     # Onboard Scan Targets
     ###################################################

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1993,6 +1993,18 @@ class TestClient(unittest.TestCase):
             body={"organizationId": organization_id, "scanTargetIds": scan_target_ids},
         )
 
+    def test_get_alerts_over_time(self):
+        organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
+        following_ids = ["d33a5808-223c-4606-bd6c-b789f39a9e60"]
+        self.sdk.get_alerts_over_time(
+            organization_id=organization_id, following_ids=following_ids
+        )
+        self.sdk._request.assert_called_once_with(
+            "POST",
+            "/alerts/summaries/following/resolvedovertime",
+            body={"organizationId": organization_id, "followingIds": following_ids},
+        )
+
     def test_get_scan_targets_following_summary(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         scan_target_kinds = [zanshinsdk.ScanTargetKind.DOMAIN]


### PR DESCRIPTION
This PR adds the `get_alerts_over_time` method to the SDK, which calls the `POST /alerts/summaries/following/resolvedovertime` endpoint.

### What's included:

- New method: `get_alerts_over_time`
- Supports:
  - `organization_id` (required)
  - `following_ids` (optional)
  - `severities` (optional, accepts enum or string)
  - `dates` (optional, accepts list of YYYY-MM-DD)
- Validation for UUIDs, enums, and date format
- Unit test for request construction

Part of the SDK/CLI alignment work.
