### PR TITLE
fix typos and clarify method naming for alerts summary

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -2090,7 +2090,7 @@ class Client:
             if isinstance(scan_target_tags, str):
                 scan_target_tags = [scan_target_tags]
             validate_class(scan_target_tags, Iterable)
-            body["scanTargetTags"] = [validate_uuid(x) for x in scan_target_tags]
+            body["scanTargetTags"] = [validate_class(x, str) for x in scan_target_tags]
         if include_empty_scan_target_tags is not None:
             validate_class(include_empty_scan_target_tags, bool)
             body["includeEmptyScanTargetTags"] = include_empty_scan_target_tags

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -2809,7 +2809,7 @@ class Client:
         dates: Optional[Iterable[str]] = None,
     ) -> Dict:
         """
-        Get following  alerts over time.
+        Get following alerts over time.
         <https://api.zanshin.tenchisecurity.com/#tag/Summaries/operation/alertFollowingResolvedOverTimeSummary>
         :param organization_id: Organization that the requester belongs to, data will be fetched from this organization followings
         :param following_ids: Organizations to filter following alerts from (FollowingIds), all ids must belong to following organizations. not passing the field will fetch from all

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -2801,7 +2801,7 @@ class Client:
             body=body,
         ).json()
 
-    def get_alerts_over_time(
+    def get_following_alerts_over_time(
         self,
         organization_id: Union[UUID, str],
         following_ids: Optional[Iterable[Union[UUID, str]]] = None,
@@ -2809,7 +2809,7 @@ class Client:
         dates: Optional[Iterable[str]] = None,
     ) -> Dict:
         """
-        Get scan target following summary.
+        Get following  alerts over time.
         <https://api.zanshin.tenchisecurity.com/#tag/Summaries/operation/alertFollowingResolvedOverTimeSummary>
         :param organization_id: Organization that the requester belongs to, data will be fetched from this organization followings
         :param following_ids: Organizations to filter following alerts from (FollowingIds), all ids must belong to following organizations. not passing the field will fetch from all

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -2019,7 +2019,7 @@ class Client:
         self,
         organization_id: Union[UUID, str],
         scan_target_ids: Optional[Iterable[Union[UUID, str]]] = None,
-        scan_tagert_tags: Optional[Iterable[str]] = None,
+        scan_target_tags: Optional[Iterable[str]] = None,
         include_empty_scan_target_tags: Optional[bool] = None,
         rules: Optional[Iterable[str]] = None,
         states: Optional[Iterable[AlertState]] = None,
@@ -2086,11 +2086,11 @@ class Client:
                 scan_target_ids = [scan_target_ids]
             validate_class(scan_target_ids, Iterable)
             body["scanTargetIds"] = [validate_uuid(x) for x in scan_target_ids]
-        if scan_tagert_tags:
-            if isinstance(scan_tagert_tags, str):
-                scan_tagert_tags = [scan_tagert_tags]
-            validate_class(scan_tagert_tags, Iterable)
-            body["scanTargetTags"] = [validate_uuid(x) for x in scan_tagert_tags]
+        if scan_target_tags:
+            if isinstance(scan_target_tags, str):
+                scan_target_tags = [scan_target_tags]
+            validate_class(scan_target_tags, Iterable)
+            body["scanTargetTags"] = [validate_uuid(x) for x in scan_target_tags]
         if include_empty_scan_target_tags is not None:
             validate_class(include_empty_scan_target_tags, bool)
             body["includeEmptyScanTargetTags"] = include_empty_scan_target_tags
@@ -2105,7 +2105,7 @@ class Client:
         self,
         organization_id: Union[UUID, str],
         scan_target_ids: Optional[Iterable[Union[UUID, str]]] = None,
-        scan_tagert_tags: Optional[Iterable[str]] = None,
+        scan_target_tags: Optional[Iterable[str]] = None,
         include_empty_scan_target_tags: Optional[bool] = None,
         rules: Optional[Iterable[str]] = None,
         states: Optional[Iterable[AlertState]] = None,
@@ -2152,7 +2152,7 @@ class Client:
         page = self._get_grouped_alerts_page(
             organization_id,
             scan_target_ids=scan_target_ids,
-            scan_tagert_tags=scan_tagert_tags,
+            scan_target_tags=scan_target_tags,
             include_empty_scan_target_tags=include_empty_scan_target_tags,
             cursor=cursor,
             page_size=page_size,
@@ -2177,7 +2177,7 @@ class Client:
             page = self._get_grouped_alerts_page(
                 organization_id,
                 scan_target_ids,
-                scan_tagert_tags=scan_tagert_tags,
+                scan_target_tags=scan_target_tags,
                 include_empty_scan_target_tags=include_empty_scan_target_tags,
                 cursor=page.get("cursor"),
                 page_size=page_size,

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1993,10 +1993,10 @@ class TestClient(unittest.TestCase):
             body={"organizationId": organization_id, "scanTargetIds": scan_target_ids},
         )
 
-    def test_get_alerts_over_time(self):
+    def test_get_following_alerts_over_time(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         following_ids = ["d33a5808-223c-4606-bd6c-b789f39a9e60"]
-        self.sdk.get_alerts_over_time(
+        self.sdk.get_following_alerts_over_time(
             organization_id=organization_id, following_ids=following_ids
         )
         self.sdk._request.assert_called_once_with(

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1824,7 +1824,7 @@ class TestClient(unittest.TestCase):
         self.sdk._get_grouped_alerts_page.assert_called_once_with(
             organization_id,
             scan_target_ids=None,
-            scan_tagert_tags=None,
+            scan_target_tags=None,
             include_empty_scan_target_tags=None,
             cursor=None,
             page_size=100,


### PR DESCRIPTION
### What's included:

- Renamed variable `scan_tagert_tags` → `scan_target_tags`
- Renamed method `get_alerts_over_time` → `get_following_alerts_over_time`
- Updated the method docstring to clarify that it fetches alerts **from following organizations**, not from the current org
- Updated the corresponding unit test to match the new method name

These changes improve clarity and consistency in the SDK interface.
