### PR TITLE
fix update iter alert comment to use cursor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 8.0.1
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.3.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         args:
@@ -23,7 +23,7 @@ repos:
             "--statistics"
           ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/zanshinsdk/alerts_history.py
+++ b/zanshinsdk/alerts_history.py
@@ -3,6 +3,7 @@
 This module allows persistent iteration of alerts. Some use cases include opening tickets based
 on new alerts, or even automating responses for some high-confidence alerts.
 """
+
 import json
 from os.path import isfile
 from typing import Dict, Iterator

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -60,7 +60,7 @@ from zanshinsdk.version import __version__ as sdk_version
 
 CONFIG_DIR = Path.home() / ".tenchi"
 CONFIG_FILE = CONFIG_DIR / "config"
-    
+
 
 class ScanTargetSchedule(BaseModel):
     frequency: Frequency
@@ -2463,9 +2463,7 @@ class Client:
         :param alert_id: the ID of the alert
         :return:
         """
-        page = self._get_alert_comment_page(
-            alert_id=alert_id, page_size=page_size
-        )
+        page = self._get_alert_comment_page(alert_id=alert_id, page_size=page_size)
         yield from page.get("data", [])
         while page.get("cursor"):
             page = self._get_alert_comment_page(

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import pprint
 import sys
 import time
 from configparser import RawConfigParser
@@ -61,7 +60,6 @@ from zanshinsdk.version import __version__ as sdk_version
 
 CONFIG_DIR = Path.home() / ".tenchi"
 CONFIG_FILE = CONFIG_DIR / "config"
-pp = pprint.PrettyPrinter(indent=2)
     
 
 class ScanTargetSchedule(BaseModel):
@@ -1480,7 +1478,6 @@ class Client:
         :return: a JSON decoded alerts
         :return:
         """
-        pp.pprint(f"page_size: {page_size}")
         validate_int(page_size, min_value=1, required=True)
         body = {}
         params = {"size": page_size}

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -405,7 +405,7 @@ class Client:
         :return: a dict representing the organization of this invite
         """
         return self._request(
-            "POST", f"/me/invites/{invite_id}/accept"
+            "POST", f"/me/invites/{validate_uuid(invite_id)}/accept"
         ).json()
 
     ###################################################

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import pprint
 import sys
 import time
 from configparser import RawConfigParser
@@ -60,7 +61,8 @@ from zanshinsdk.version import __version__ as sdk_version
 
 CONFIG_DIR = Path.home() / ".tenchi"
 CONFIG_FILE = CONFIG_DIR / "config"
-
+pp = pprint.PrettyPrinter(indent=2)
+    
 
 class ScanTargetSchedule(BaseModel):
     frequency: Frequency
@@ -405,7 +407,7 @@ class Client:
         :return: a dict representing the organization of this invite
         """
         return self._request(
-            "POST", f"/me/invites/{validate_uuid(invite_id)}/accept"
+            "POST", f"/me/invites/{invite_id}/accept"
         ).json()
 
     ###################################################
@@ -1478,6 +1480,7 @@ class Client:
         :return: a JSON decoded alerts
         :return:
         """
+        pp.pprint(f"page_size: {page_size}")
         validate_int(page_size, min_value=1, required=True)
         body = {}
         params = {"size": page_size}
@@ -2441,12 +2444,13 @@ class Client:
     def _get_alert_comment_page(
         self,
         alert_id: Union[UUID, str],
-        page: Optional[int] = 1,
+        cursor: Optional[str] = None,
         page_size: Optional[int] = 100,
     ) -> Dict:
-        validate_int(page, min_value=1, required=True)
         validate_int(page_size, min_value=1, required=True)
-        params = {"page": page, "pageSize": page_size}
+        params = {"size": page_size}
+        if cursor:
+            params["cursor"] = cursor
         return self._request(
             "GET", f"/alerts/{validate_uuid(alert_id)}/comments", params=params
         ).json()
@@ -2463,16 +2467,12 @@ class Client:
         :return:
         """
         page = self._get_alert_comment_page(
-            alert_id=alert_id, page_size=page_size, page=1
+            alert_id=alert_id, page_size=page_size
         )
         yield from page.get("data", [])
-        for page_number in range(
-            2, int(ceil(page.get("total", 0) / float(page_size))) + 1
-        ):
+        while page.get("cursor"):
             page = self._get_alert_comment_page(
-                alert_id=alert_id,
-                page_size=page_size,
-                page=page_number,
+                alert_id=alert_id, page_size=page_size, cursor=page.get("cursor")
             )
             yield from page.get("data", [])
 

--- a/zanshinsdk/following_alerts_history.py
+++ b/zanshinsdk/following_alerts_history.py
@@ -3,6 +3,7 @@
 This module allows persistent iteration of alerts. Some use cases include opening tickets based
 on new alerts, or even automating responses for some high-confidence alerts.
 """
+
 import json
 from os.path import isfile
 from typing import Dict, Iterator

--- a/zanshinsdk/iterator.py
+++ b/zanshinsdk/iterator.py
@@ -3,6 +3,7 @@
 This module allows persistent iteration of alerts. Some use cases include opening tickets based
 on new alerts, or even automating responses for some high-confidence alerts.
 """
+
 from abc import ABCMeta, abstractmethod
 from typing import Dict, Iterator
 

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -2505,29 +2505,26 @@ class TestClient(unittest.TestCase):
 
     def test_get_alert_comment_page(self):
         alert_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
-        page = 1
         page_size = 100
+        cursor = None
 
-        self.sdk._get_alert_comment_page(alert_id, page=page, page_size=page_size)
+        self.sdk._get_alert_comment_page(alert_id, page_size=page_size, cursor=cursor)
 
         self.sdk._request.assert_called_once_with(
             "GET",
             f"/alerts/{alert_id}/comments",
-            params={
-                "page": page,
-                "pageSize": page_size,
-            },
+            params={"size": page_size},
         )
 
     @patch("zanshinsdk.client.Client._get_alert_comment_page")
     def test_iter_alert_comments(self, request):
         alert_id = "e22f4225-43e9-4922-b6b8-8b0620bdb110"
         page_size = 2
-        total_comments = 5
 
+        # Simulate cursor-based pagination
         request.side_effect = [
-            {"data": ["comment1", "comment2"], "total": total_comments},
-            {"data": ["comment3", "comment4"]},
+            {"data": ["comment1", "comment2"], "cursor": "cursor2"},
+            {"data": ["comment3", "comment4"], "cursor": "cursor3"},
             {"data": ["comment5"]},
         ]
 
@@ -2540,9 +2537,9 @@ class TestClient(unittest.TestCase):
         )
 
         expected_calls = [
-            call(alert_id=alert_id, page_size=page_size, page=1),
-            call(alert_id=alert_id, page_size=page_size, page=2),
-            call(alert_id=alert_id, page_size=page_size, page=3),
+            call(alert_id=alert_id, page_size=page_size),
+            call(alert_id=alert_id, page_size=page_size, cursor="cursor2"),
+            call(alert_id=alert_id, page_size=page_size, cursor="cursor3"),
         ]
         self.sdk._get_alert_comment_page.assert_has_calls(expected_calls)
 


### PR DESCRIPTION
This pull request updates the alert comments pagination logic in the `zanshinsdk` client to use cursor-based pagination instead of page-number-based pagination. The changes affect both the implementation and the related tests, ensuring the client is compatible with APIs that use cursors for paginating results.

**Migration to cursor-based pagination:**

* Updated the `_get_alert_comment_page` method in `zanshinsdk/client.py` to accept a `cursor` parameter instead of a `page` parameter, and to use `"cursor"` and `"size"` in the request parameters instead of `"page"` and `"pageSize"`.
* Modified the `iter_alert_comments` method to iterate using the returned `cursor` value from the API response, rather than incrementing a page number.

**Test updates:**

* Adjusted the `test_get_alert_comment_page` and `test_iter_alert_comments` tests in `zanshinsdk/tests/test_client.py` to match the new cursor-based pagination logic, including simulating cursor values in mocked responses.
* Updated the expected calls in `test_iter_alert_comments` to reflect the use of the `cursor` argument instead of `page`.

#### Related

Issue #184 