### PR TITLE
Migrate pagination from page to slice for multiple api routes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 8.0.1
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.3.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         args:
@@ -23,7 +23,7 @@ repos:
             "--statistics"
           ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/zanshinsdk/alerts_history.py
+++ b/zanshinsdk/alerts_history.py
@@ -3,6 +3,7 @@
 This module allows persistent iteration of alerts. Some use cases include opening tickets based
 on new alerts, or even automating responses for some high-confidence alerts.
 """
+
 import json
 from os.path import isfile
 from typing import Dict, Iterator

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -431,13 +431,32 @@ class Client:
     # Account API key
     ###################################################
 
+    def _get_api_keys_page(self, cursor: Optional[str] = None, size: int = 100) -> Dict:
+        """
+        Internal method to get a page of the API keys of current logged user.
+        <https://api.zanshin.tenchisecurity.com/#operation/getMyApiKeys>
+        :param cursor: the cursor for pagination
+        :param size: the number of items per page
+        :return: a dict representing the page of API keys
+        """
+        validate_int(size, min_value=1, required=True)
+        params = {"size": size}
+        if cursor:
+            validate_class(cursor, str)
+            params["cursor"] = cursor
+        return self._request("GET", "/me/apikeys", params=params).json()
+
     def iter_api_keys(self) -> Iterator[Dict]:
         """
         Iterates over the API keys of current logged user.
         <https://api.zanshin.tenchisecurity.com/#operation/getMyApiKeys>
         :return: an iterator over the api keys objects
         """
-        yield from self._request("GET", "/me/apikeys").json()
+        page = self._get_api_keys_page(size=100)
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_api_keys_page(cursor=page["cursor"], size=100)
+            yield from page.get("data", [])
 
     def create_api_key(self, name: Optional[str]) -> Dict:
         """

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -570,6 +570,29 @@ class Client:
     # Organization Member
     ###################################################
 
+    def _get_organization_members_page(
+        self,
+        organization_id: Union[UUID, str],
+        cursor: Optional[str] = None,
+        size: int = 100,
+    ) -> Dict:
+        """
+        Gets a page of organization members.
+        <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationMembers>
+        :param organization_id: the ID of the organization
+        :param cursor: the cursor for pagination
+        :param size: the number of items per page
+        :return: a dict representing the page of organization members
+        """
+        params = {"size": size}
+        if cursor:
+            params["cursor"] = cursor
+        return self._request(
+            "GET",
+            f"/organizations/{validate_uuid(organization_id)}/members",
+            params=params,
+        ).json()
+
     def iter_organization_members(
         self, organization_id: Union[UUID, str]
     ) -> Iterator[Dict]:
@@ -579,9 +602,13 @@ class Client:
         :param organization_id: the ID of the organization
         :return: an iterator over the organization members objects
         """
-        yield from self._request(
-            "GET", f"/organizations/{validate_uuid(organization_id)}/members"
-        ).json()
+        page = self._get_organization_members_page(organization_id, size=100)
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_organization_members_page(
+                organization_id, cursor=page["cursor"], size=100
+            )
+            yield from page.get("data", [])
 
     def get_organization_member(
         self, organization_id: Union[UUID, str], member_id: Union[UUID, str]

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -379,13 +379,32 @@ class Client:
     # Account Invites
     ###################################################
 
+    def _get_invite_page(self, cursor: Optional[str] = None, size: int = 100) -> Dict:
+        """
+        Internal method to get a page of the invites of current logged user.
+        <https://api.zanshin.tenchisecurity.com/#operation/getInvites>
+        :param cursor: the cursor for pagination
+        :param size: the number of items per page
+        :return: a dict representing the page of invites
+        """
+        validate_int(size, min_value=1, required=True)
+        params = {"size": size}
+        if cursor:
+            validate_class(cursor, str)
+            params["cursor"] = cursor
+        return self._request("GET", "/me/invites", params=params).json()
+
     def iter_invites(self) -> Iterator[Dict]:
         """
         Iterates over the invites of current logged user.
         <https://api.zanshin.tenchisecurity.com/#operation/getInvites>
         :return: an iterator over the invites objects
         """
-        yield from self._request("GET", "/me/invites").json()
+        page = self._get_invite_page(size=100)
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_invite_page(cursor=page["cursor"], size=100)
+            yield from page.get("data", [])
 
     def get_invite(self, invite_id: Union[UUID, str]) -> Dict:
         """

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -379,7 +379,7 @@ class Client:
     # Account Invites
     ###################################################
 
-    def _get_invite_page(self, cursor: Optional[str] = None, size: int = 100) -> Dict:
+    def _get_invite_page(self, cursor: Optional[str] = None, size: int = 1000) -> Dict:
         """
         Internal method to get a page of the invites of current logged user.
         <https://api.zanshin.tenchisecurity.com/#operation/getInvites>
@@ -400,10 +400,13 @@ class Client:
         <https://api.zanshin.tenchisecurity.com/#operation/getInvites>
         :return: an iterator over the invites objects
         """
-        page = self._get_invite_page(size=100)
+        page = self._get_invite_page(size=1000)
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
-            page = self._get_invite_page(cursor=page["cursor"], size=100)
+            page = self._get_invite_page(cursor=page["cursor"], size=1000)
             yield from page.get("data", [])
 
     def get_invite(self, invite_id: Union[UUID, str]) -> Dict:
@@ -431,7 +434,7 @@ class Client:
     # Account API key
     ###################################################
 
-    def _get_api_keys_page(self, cursor: Optional[str] = None, size: int = 100) -> Dict:
+    def _get_api_keys_page(self, cursor: Optional[str] = None, size: int = 1000) -> Dict:
         """
         Internal method to get a page of the API keys of current logged user.
         <https://api.zanshin.tenchisecurity.com/#operation/getMyApiKeys>
@@ -452,10 +455,13 @@ class Client:
         <https://api.zanshin.tenchisecurity.com/#operation/getMyApiKeys>
         :return: an iterator over the api keys objects
         """
-        page = self._get_api_keys_page(size=100)
+        page = self._get_api_keys_page(size=1000)
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
-            page = self._get_api_keys_page(cursor=page["cursor"], size=100)
+            page = self._get_api_keys_page(cursor=page["cursor"], size=1000)
             yield from page.get("data", [])
 
     def create_api_key(self, name: Optional[str]) -> Dict:
@@ -507,10 +513,13 @@ class Client:
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizations>
         :return: an iterator over the organizations objects
         """
-        page = self._get_organizations_page(size=100)
+        page = self._get_organizations_page(size=1000)
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
-            page = self._get_organizations_page(cursor=page["cursor"], size=100)
+            page = self._get_organizations_page(cursor=page["cursor"], size=1000)
             yield from page.get("data", [])
 
     def get_organization(self, organization_id: Union[UUID, str]) -> Dict:
@@ -574,7 +583,7 @@ class Client:
         self,
         organization_id: Union[UUID, str],
         cursor: Optional[str] = None,
-        size: int = 100,
+        size: int = 1000,
     ) -> Dict:
         """
         Gets a page of organization members.
@@ -602,11 +611,14 @@ class Client:
         :param organization_id: the ID of the organization
         :return: an iterator over the organization members objects
         """
-        page = self._get_organization_members_page(organization_id, size=100)
+        page = self._get_organization_members_page(organization_id, size=1000)
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
             page = self._get_organization_members_page(
-                organization_id, cursor=page["cursor"], size=100
+                organization_id, cursor=page["cursor"], size=1000
             )
             yield from page.get("data", [])
 
@@ -705,7 +717,7 @@ class Client:
         self,
         organization_id: Union[UUID, str],
         cursor: Optional[str] = None,
-        size: int = 100,
+        size: int = 1000,
     ) -> Dict:
         """
         Gets a page of organization members invites.
@@ -734,11 +746,14 @@ class Client:
         :param organization_id: the ID of the organization
         :return: an iterator over the organization members invites objects
         """
-        page = self._get_organization_members_invites_page(organization_id, size=100)
+        page = self._get_organization_members_invites_page(organization_id, size=1000)
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
             page = self._get_organization_members_invites_page(
-                organization_id, cursor=page["cursor"], size=100
+                organization_id, cursor=page["cursor"], size=1000
             )
             yield from page.get("data", [])
 
@@ -817,7 +832,7 @@ class Client:
         self,
         organization_id: Union[UUID, str],
         cursor: Optional[str] = None,
-        size: int = 100,
+        size: int = 1000,
     ) -> Dict:
         """
         Internal method to get a page of the follower of an organization.
@@ -847,11 +862,14 @@ class Client:
         :param organization_id: the ID of the organization
         :return: an iterator over the organization followers objects
         """
-        page = self._get_organization_follower_page(organization_id, size=100)
+        page = self._get_organization_follower_page(organization_id, size=1000)
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
             page = self._get_organization_follower_page(
-                organization_id, cursor=page["cursor"], size=100
+                organization_id, cursor=page["cursor"], size=1000
             )
             yield from page.get("data", [])
 
@@ -879,7 +897,7 @@ class Client:
         self,
         organization_id: Union[UUID, str],
         cursor: Optional[str] = None,
-        size: int = 100,
+        size: int = 1000,
     ) -> Dict:
         """
         Internal method to get a page of the follower requests of an organization.
@@ -909,11 +927,14 @@ class Client:
         :param organization_id: the ID of the organization
         :return: an iterator over the organization follower requests objects
         """
-        page = self._get_organization_follower_request_page(organization_id, size=100)
+        page = self._get_organization_follower_request_page(organization_id, size=1000)
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
             page = self._get_organization_follower_request_page(
-                organization_id, cursor=page["cursor"], size=100
+                organization_id, cursor=page["cursor"], size=1000
             )
             yield from page.get("data", [])
 
@@ -976,7 +997,7 @@ class Client:
         self,
         organization_id: Union[UUID, str],
         cursor: Optional[str] = None,
-        size: int = 100,
+        size: int = 1000,
     ) -> Dict:
         """
         Internal method to get a page of the following of an organization.
@@ -1005,12 +1026,15 @@ class Client:
         :return: an iterator over the JSON decoded followed organizations
         """
         page = self._get_organization_following_page(
-            organization_id, cursor=None, size=100
+            organization_id, cursor=None, size=1000
         )
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
             page = self._get_organization_following_page(
-                organization_id, cursor=page["cursor"], size=100
+                organization_id, cursor=page["cursor"], size=1000
             )
             yield from page.get("data", [])
 
@@ -1103,7 +1127,7 @@ class Client:
         self,
         organization_id: Union[UUID, str],
         cursor: Optional[str] = None,
-        size: int = 100,
+        size: int = 1000,
     ) -> Dict:
         """
         Internal method to get a page of the scan targets of an organization.
@@ -1133,11 +1157,14 @@ class Client:
         :param organization_id: the ID of the organization
         : return: an iterator over the scan target objects
         """
-        page = self._get_organization_scan_targets_page(organization_id, size=100)
+        page = self._get_organization_scan_targets_page(organization_id, size=1000)
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
             page = self._get_organization_scan_targets_page(
-                organization_id, cursor=page["cursor"], size=100
+                organization_id, cursor=page["cursor"], size=1000
             )
             yield from page.get("data", [])
 
@@ -1456,7 +1483,7 @@ class Client:
         self,
         organization_id: Union[UUID, str],
         cursor: Optional[str] = None,
-        size: int = 100,
+        size: int = 1000,
     ) -> Dict:
         """
         Internal method to get a page of the scan target groups of an organization.
@@ -1486,11 +1513,14 @@ class Client:
         :param organization_id: the ID of the organization
         : return: an iterator over the scan target groups
         """
-        page = self._get_organization_scan_target_groups(organization_id, size=100)
+        page = self._get_organization_scan_target_groups(organization_id, size=1000)
+        if isinstance(page, list) or not page.get("data"):
+            yield from page
+            return
         yield from page.get("data", [])
         while page.get("cursor"):
             page = self._get_organization_scan_target_groups(
-                organization_id, cursor=page["cursor"], size=100
+                organization_id, cursor=page["cursor"], size=1000
             )
             yield from page.get("data", [])
 

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -700,7 +700,10 @@ class Client:
     ###################################################
 
     def _get_organization_follower_page(
-        self, organization_id: Union[UUID, str], cursor: Optional[str] = None, size: int = 100
+        self,
+        organization_id: Union[UUID, str],
+        cursor: Optional[str] = None,
+        size: int = 100,
     ) -> Dict:
         """
         Internal method to get a page of the follower of an organization.
@@ -716,7 +719,9 @@ class Client:
             validate_class(cursor, str)
             params["cursor"] = cursor
         return self._request(
-            "GET", f"/organizations/{validate_uuid(organization_id)}/followers", params=params
+            "GET",
+            f"/organizations/{validate_uuid(organization_id)}/followers",
+            params=params,
         ).json()
 
     def iter_organization_followers(
@@ -756,6 +761,31 @@ class Client:
     # Organization Follower Request
     ###################################################
 
+    def _get_organization_follower_request_page(
+        self,
+        organization_id: Union[UUID, str],
+        cursor: Optional[str] = None,
+        size: int = 100,
+    ) -> Dict:
+        """
+        Internal method to get a page of the follower requests of an organization.
+        <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationFollowRequests>
+        :param organization_id: the ID of the organization
+        :param cursor: the cursor for pagination
+        :param size: the number of items per page
+        :return: a dict representing the page of organization follower requests
+        """
+        validate_int(size, min_value=1, required=True)
+        params = {"size": size}
+        if cursor:
+            validate_class(cursor, str)
+            params["cursor"] = cursor
+        return self._request(
+            "GET",
+            f"/organizations/{validate_uuid(organization_id)}/followers/requests",
+            params=params,
+        ).json()
+
     def iter_organization_follower_requests(
         self, organization_id: Union[UUID, str]
     ) -> Iterator[Dict]:
@@ -765,9 +795,13 @@ class Client:
         :param organization_id: the ID of the organization
         :return: an iterator over the organization follower requests objects
         """
-        yield from self._request(
-            "GET", f"/organizations/{validate_uuid(organization_id)}/followers/requests"
-        ).json()
+        page = self._get_organization_follower_request_page(organization_id, size=100)
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_organization_follower_request_page(
+                organization_id, cursor=page["cursor"], size=100
+            )
+            yield from page.get("data", [])
 
     def create_organization_follower_request(
         self, organization_id: Union[UUID, str], token: Union[UUID, str]
@@ -825,7 +859,10 @@ class Client:
     ###################################################
 
     def _get_organization_following_page(
-        self, organization_id: Union[UUID, str], cursor: Optional[str] = None, size: int = 100
+        self,
+        organization_id: Union[UUID, str],
+        cursor: Optional[str] = None,
+        size: int = 100,
     ) -> Dict:
         """
         Internal method to get a page of the following of an organization.

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -484,13 +484,34 @@ class Client:
     # Organization
     ###################################################
 
+    def _get_organizations_page(
+        self, cursor: Optional[str] = None, size: int = 100
+    ) -> Dict:
+        """
+        Internal method to get a page of the organizations of current logged user.
+        <https://api.zanshin.tenchisecurity.com/#operation/getOrganizations>
+        :param cursor: the cursor for pagination
+        :param size: the number of items per page
+        :return: a dict representing the page of organizations
+        """
+        validate_int(size, min_value=1, required=True)
+        params = {"size": size}
+        if cursor:
+            validate_class(cursor, str)
+            params["cursor"] = cursor
+        return self._request("GET", "/organizations", params=params).json()
+
     def iter_organizations(self) -> Iterator[Dict]:
         """
         Iterates over organizations of current logged user.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizations>
         :return: an iterator over the organizations objects
         """
-        yield from self._request("GET", "/organizations").json()
+        page = self._get_organizations_page(size=100)
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_organizations_page(cursor=page["cursor"], size=100)
+            yield from page.get("data", [])
 
     def get_organization(self, organization_id: Union[UUID, str]) -> Dict:
         """

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -699,6 +699,26 @@ class Client:
     # Organization Follower
     ###################################################
 
+    def _get_organization_follower_page(
+        self, organization_id: Union[UUID, str], cursor: Optional[str] = None, size: int = 100
+    ) -> Dict:
+        """
+        Internal method to get a page of the follower of an organization.
+        <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationFollowers>
+        :param organization_id: the ID of the organization
+        :param cursor: the cursor for pagination
+        :param size: the number of items per page
+        :return: a dict representing the page of organization followers
+        """
+        validate_int(size, min_value=1, required=True)
+        params = {"size": size}
+        if cursor:
+            validate_class(cursor, str)
+            params["cursor"] = cursor
+        return self._request(
+            "GET", f"/organizations/{validate_uuid(organization_id)}/followers", params=params
+        ).json()
+
     def iter_organization_followers(
         self, organization_id: Union[UUID, str]
     ) -> Iterator[Dict]:
@@ -708,9 +728,13 @@ class Client:
         :param organization_id: the ID of the organization
         :return: an iterator over the organization followers objects
         """
-        yield from self._request(
-            "GET", f"/organizations/{validate_uuid(organization_id)}/followers"
-        ).json()
+        page = self._get_organization_follower_page(organization_id, size=100)
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_organization_follower_page(
+                organization_id, cursor=page["cursor"], size=100
+            )
+            yield from page.get("data", [])
 
     def stop_organization_follower(
         self, organization_id: Union[UUID, str], follower_id: Union[UUID, str]
@@ -801,8 +825,8 @@ class Client:
     ###################################################
 
     def _get_organization_following_page(
-        self, organization_id: Union[UUID, str], cursor: int, size: int
-    ) -> Iterator[Dict]:
+        self, organization_id: Union[UUID, str], cursor: Optional[str] = None, size: int = 100
+    ) -> Dict:
         """
         Internal method to get a page of the following of an organization.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationFollowing>
@@ -814,7 +838,7 @@ class Client:
         params = {"size": size}
         if cursor:
             params["cursor"] = cursor
-        yield from self._request(
+        return self._request(
             "GET",
             f"/organizations/{validate_uuid(organization_id)}/following",
             params=params,

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1099,6 +1099,31 @@ class Client:
     # Organization Scan Target
     ###################################################
 
+    def _get_organization_scan_targets_page(
+        self,
+        organization_id: Union[UUID, str],
+        cursor: Optional[str] = None,
+        size: int = 100,
+    ) -> Dict:
+        """
+        Internal method to get a page of the scan targets of an organization.
+        <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationScanTargets>
+        :param organization_id: the ID of the organization
+        :param cursor: the cursor for pagination
+        :param size: the number of items per page
+        :return: a dict representing the page of scan targets
+        """
+        validate_int(size, min_value=1, required=True)
+        params = {"size": size}
+        if cursor:
+            validate_class(cursor, str)
+            params["cursor"] = cursor
+        return self._request(
+            "GET",
+            f"/organizations/{validate_uuid(organization_id)}/scantargets",
+            params=params,
+        ).json()
+
     def iter_organization_scan_targets(
         self, organization_id: Union[UUID, str]
     ) -> Iterator[Dict]:
@@ -1108,9 +1133,13 @@ class Client:
         :param organization_id: the ID of the organization
         : return: an iterator over the scan target objects
         """
-        yield from self._request(
-            "GET", f"/organizations/{validate_uuid(organization_id)}/scantargets"
-        ).json()
+        page = self._get_organization_scan_targets_page(organization_id, size=100)
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_organization_scan_targets_page(
+                organization_id, cursor=page["cursor"], size=100
+            )
+            yield from page.get("data", [])
 
     def create_organization_scan_target(
         self,

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -800,6 +800,26 @@ class Client:
     # Organization Following
     ###################################################
 
+    def _get_organization_following_page(
+        self, organization_id: Union[UUID, str], cursor: int, size: int
+    ) -> Iterator[Dict]:
+        """
+        Internal method to get a page of the following of an organization.
+        <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationFollowing>
+        :param organization_id: the ID of the organization whose followed organizations we should list
+        :param cursor: the index of the first result to return
+        :param size: the maximum number of results to return
+        :return: an iterator over the JSON decoded followed organizations in the requested page
+        """
+        params = {"size": size}
+        if cursor:
+            params["cursor"] = cursor
+        yield from self._request(
+            "GET",
+            f"/organizations/{validate_uuid(organization_id)}/following",
+            params=params,
+        ).json()
+
     def iter_organization_following(
         self, organization_id: Union[UUID, str]
     ) -> Iterator[Dict]:
@@ -809,9 +829,15 @@ class Client:
         :param organization_id: the ID of the organization whose followed organizations we should list
         :return: an iterator over the JSON decoded followed organizations
         """
-        yield from self._request(
-            "GET", f"/organizations/{validate_uuid(organization_id)}/following"
-        ).json()
+        page = self._get_organization_following_page(
+            organization_id, cursor=None, size=100
+        )
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_organization_following_page(
+                organization_id, cursor=page["cursor"], size=100
+            )
+            yield from page.get("data", [])
 
     def stop_organization_following(
         self, organization_id: Union[UUID, str], following_id: Union[UUID, str]

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -434,7 +434,9 @@ class Client:
     # Account API key
     ###################################################
 
-    def _get_api_keys_page(self, cursor: Optional[str] = None, size: int = 1000) -> Dict:
+    def _get_api_keys_page(
+        self, cursor: Optional[str] = None, size: int = 1000
+    ) -> Dict:
         """
         Internal method to get a page of the API keys of current logged user.
         <https://api.zanshin.tenchisecurity.com/#operation/getMyApiKeys>
@@ -593,6 +595,7 @@ class Client:
         :param size: the number of items per page
         :return: a dict representing the page of organization members
         """
+        validate_int(size, min_value=1)
         params = {"size": size}
         if cursor:
             params["cursor"] = cursor
@@ -1007,6 +1010,7 @@ class Client:
         :param size: the maximum number of results to return
         :return: an iterator over the JSON decoded followed organizations in the requested page
         """
+        validate_int(size, min_value=1)
         params = {"size": size}
         if cursor:
             params["cursor"] = cursor
@@ -1479,7 +1483,7 @@ class Client:
     # Organization Scan Target Groups
     ###################################################
 
-    def _get_organization_scan_target_groups(
+    def _get_organization_scan_target_groups_page(
         self,
         organization_id: Union[UUID, str],
         cursor: Optional[str] = None,
@@ -1513,13 +1517,15 @@ class Client:
         :param organization_id: the ID of the organization
         : return: an iterator over the scan target groups
         """
-        page = self._get_organization_scan_target_groups(organization_id, size=1000)
+        page = self._get_organization_scan_target_groups_page(
+            organization_id, size=1000
+        )
         if isinstance(page, list) or not page.get("data"):
             yield from page
             return
         yield from page.get("data", [])
         while page.get("cursor"):
-            page = self._get_organization_scan_target_groups(
+            page = self._get_organization_scan_target_groups_page(
                 organization_id, cursor=page["cursor"], size=1000
             )
             yield from page.get("data", [])

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -1452,6 +1452,31 @@ class Client:
     # Organization Scan Target Groups
     ###################################################
 
+    def _get_organization_scan_target_groups(
+        self,
+        organization_id: Union[UUID, str],
+        cursor: Optional[str] = None,
+        size: int = 100,
+    ) -> Dict:
+        """
+        Internal method to get a page of the scan target groups of an organization.
+        <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationScanTargetGroups>
+        :param organization_id: the ID of the organization
+        :param cursor: the cursor for pagination
+        :param size: the number of items per page
+        :return: a dict representing the page of scan target groups
+        """
+        validate_int(size, min_value=1, required=True)
+        params = {"size": size}
+        if cursor:
+            validate_class(cursor, str)
+            params["cursor"] = cursor
+        return self._request(
+            "GET",
+            f"/organizations/{validate_uuid(organization_id)}/scantargetgroups",
+            params=params,
+        ).json()
+
     def iter_organization_scan_target_groups(
         self, organization_id: Union[UUID, str]
     ) -> Iterator[Dict]:
@@ -1461,9 +1486,13 @@ class Client:
         :param organization_id: the ID of the organization
         : return: an iterator over the scan target groups
         """
-        yield from self._request(
-            "GET", f"/organizations/{validate_uuid(organization_id)}/scantargetgroups"
-        ).json()
+        page = self._get_organization_scan_target_groups(organization_id, size=100)
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_organization_scan_target_groups(
+                organization_id, cursor=page["cursor"], size=100
+            )
+            yield from page.get("data", [])
 
     def get_organization_scan_target_group(
         self, organization_id: Union[UUID, str], scan_target_group_id: Union[UUID, str]

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -701,6 +701,30 @@ class Client:
     # Organization Member Invite
     ###################################################
 
+    def _get_organization_members_invites_page(
+        self,
+        organization_id: Union[UUID, str],
+        cursor: Optional[str] = None,
+        size: int = 100,
+    ) -> Dict:
+        """
+        Gets a page of organization members invites.
+        <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationInvites>
+        :param organization_id: the ID of the organization
+        :param cursor: the cursor for pagination
+        :param size: the number of items per page
+        :return: a dict representing the page of organization members invites
+        """
+        validate_int(size, min_value=1, required=True)
+        params = {"size": size}
+        if cursor:
+            params["cursor"] = cursor
+        return self._request(
+            "GET",
+            f"/organizations/{validate_uuid(organization_id)}/invites",
+            params=params,
+        ).json()
+
     def iter_organization_members_invites(
         self, organization_id: Union[UUID, str]
     ) -> Iterator[Dict]:
@@ -710,9 +734,13 @@ class Client:
         :param organization_id: the ID of the organization
         :return: an iterator over the organization members invites objects
         """
-        yield from self._request(
-            "GET", f"/organizations/{validate_uuid(organization_id)}/invites"
-        ).json()
+        page = self._get_organization_members_invites_page(organization_id, size=100)
+        yield from page.get("data", [])
+        while page.get("cursor"):
+            page = self._get_organization_members_invites_page(
+                organization_id, cursor=page["cursor"], size=100
+            )
+            yield from page.get("data", [])
 
     def create_organization_members_invite(
         self,

--- a/zanshinsdk/following_alerts_history.py
+++ b/zanshinsdk/following_alerts_history.py
@@ -3,6 +3,7 @@
 This module allows persistent iteration of alerts. Some use cases include opening tickets based
 on new alerts, or even automating responses for some high-confidence alerts.
 """
+
 import json
 from os.path import isfile
 from typing import Dict, Iterator

--- a/zanshinsdk/iterator.py
+++ b/zanshinsdk/iterator.py
@@ -3,6 +3,7 @@
 This module allows persistent iteration of alerts. Some use cases include opening tickets based
 on new alerts, or even automating responses for some high-confidence alerts.
 """
+
 from abc import ABCMeta, abstractmethod
 from typing import Dict, Iterator
 

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -924,17 +924,26 @@ class TestClient(unittest.TestCase):
     # Organization Scan Target
     ###################################################
 
-    def test_iter_organization_scan_targets(self):
+    @patch("zanshinsdk.client.Client._get_organization_scan_targets_page")
+    def test_iter_organization_scan_targets(self, mock_get_page):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-
-        try:
-            next(self.sdk.iter_organization_scan_targets(organization_id))
-        except StopIteration:
-            pass
-
-        self.sdk._request.assert_called_once_with(
-            "GET", f"/organizations/{organization_id}/scantargets"
+        mock_get_page.side_effect = [
+            {"data": ["target1", "target2"], "cursor": "cursor2"},
+            {"data": ["target3", "target4"], "cursor": "cursor3"},
+            {"data": ["target5"]},
+        ]
+        self.sdk._get_organization_scan_targets_page = mock_get_page
+        iterator = self.sdk.iter_organization_scan_targets(organization_id)
+        results = list(iterator)
+        self.assertEqual(
+            results, ["target1", "target2", "target3", "target4", "target5"]
         )
+        expected_calls = [
+            call(organization_id, size=100),
+            call(organization_id, cursor="cursor2", size=100),
+            call(organization_id, cursor="cursor3", size=100),
+        ]
+        mock_get_page.assert_has_calls(expected_calls)
 
     def test_create_organization_scan_target_AWS(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -1273,7 +1273,7 @@ class TestClient(unittest.TestCase):
     # Organization Scan Target Groups
     ###################################################
 
-    @patch("zanshinsdk.Client._get_organization_scan_target_groups")
+    @patch("zanshinsdk.Client._get_organization_scan_target_groups_page")
     def test_iter_organization_scan_target_groups(self, mock_get_groups):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
         mock_get_groups.side_effect = [
@@ -1281,7 +1281,7 @@ class TestClient(unittest.TestCase):
             {"data": ["group3", "group4"], "cursor": "cursor3"},
             {"data": ["group5"]},
         ]
-        self.sdk._get_organization_scan_target_groups = mock_get_groups
+        self.sdk._get_organization_scan_target_groups_page = mock_get_groups
         iterator = self.sdk.iter_organization_scan_target_groups(organization_id)
         results = list(iterator)
         self.assertEqual(results, ["group1", "group2", "group3", "group4", "group5"])

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -444,13 +444,25 @@ class TestClient(unittest.TestCase):
     # Account Invites
     ###################################################
 
-    def test_iter_invites(self):
-        try:
-            next(self.sdk.iter_invites())
-        except StopIteration:
-            pass
-
-        self.sdk._request.assert_called_once_with("GET", "/me/invites")
+    @patch("zanshinsdk.client.Client._get_invite_page")
+    def test_iter_invites(self, mock_get_page):
+        mock_get_page.side_effect = [
+            {"data": ["invite1", "invite2"], "cursor": "cursor2"},
+            {"data": ["invite3", "invite4"], "cursor": "cursor3"},
+            {"data": ["invite5"]},
+        ]
+        self.sdk._get_invite_page = mock_get_page
+        iterator = self.sdk.iter_invites()
+        results = list(iterator)
+        self.assertEqual(
+            results, ["invite1", "invite2", "invite3", "invite4", "invite5"]
+        )
+        expected_calls = [
+            call(size=100),
+            call(cursor="cursor2", size=100),
+            call(cursor="cursor3", size=100),
+        ]
+        mock_get_page.assert_has_calls(expected_calls)
 
     def test_get_invite(self):
         invite_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -735,22 +735,18 @@ class TestClient(unittest.TestCase):
     @patch("zanshinsdk.client.Client._get_organization_follower_page")
     def test_iter_organization_followers_cursor(self, mock_get_page):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-
         # Simulate cursor-based pagination
         mock_get_page.side_effect = [
             {"data": ["follower1", "follower2"], "cursor": "cursor2"},
             {"data": ["follower3", "follower4"], "cursor": "cursor3"},
             {"data": ["follower5"]},
         ]
-
         self.sdk._get_organization_follower_page = mock_get_page
         iterator = self.sdk.iter_organization_followers(organization_id)
         results = list(iterator)
-
         self.assertEqual(
             results, ["follower1", "follower2", "follower3", "follower4", "follower5"]
         )
-
         expected_calls = [
             call(organization_id, size=100),
             call(organization_id, cursor="cursor2", size=100),
@@ -1277,26 +1273,24 @@ class TestClient(unittest.TestCase):
     # Organization Scan Target Groups
     ###################################################
 
-    def test_iter_organization_scan_target_groups(self):
+    @patch("zanshinsdk.Client._get_organization_scan_target_groups")
+    def test_iter_organization_scan_target_groups(self, mock_get_groups):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-
-        try:
-            next(self.sdk.iter_organization_scan_target_groups(organization_id))
-        except StopIteration:
-            pass
-
-        self.sdk._request.assert_called_once_with(
-            "GET", f"/organizations/{organization_id}/scantargetgroups"
-        )
-
-        with self.assertRaises(TypeError):
-            next(self.sdk.iter_organization_scan_target_groups(1))
-        with self.assertRaises(TypeError):
-            next(self.sdk.iter_organization_scan_target_groups(None))
-        with self.assertRaises(ValueError):
-            next(self.sdk.iter_organization_scan_target_groups(""))
-        with self.assertRaises(ValueError):
-            next(self.sdk.iter_organization_scan_target_groups("foo"))
+        mock_get_groups.side_effect = [
+            {"data": ["group1", "group2"], "cursor": "cursor2"},
+            {"data": ["group3", "group4"], "cursor": "cursor3"},
+            {"data": ["group5"]},
+        ]
+        self.sdk._get_organization_scan_target_groups = mock_get_groups
+        iterator = self.sdk.iter_organization_scan_target_groups(organization_id)
+        results = list(iterator)
+        self.assertEqual(results, ["group1", "group2", "group3", "group4", "group5"])
+        expected_calls = [
+            call(organization_id, size=100),
+            call(organization_id, cursor="cursor2", size=100),
+            call(organization_id, cursor="cursor3", size=100),
+        ]
+        mock_get_groups.assert_has_calls(expected_calls)
 
     def test_get_organization_scan_target_group(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -682,17 +682,31 @@ class TestClient(unittest.TestCase):
     # Organization Follower
     ###################################################
 
-    def test_iter_organization_followers(self):
+    @patch("zanshinsdk.client.Client._get_organization_follower_page")
+    def test_iter_organization_followers_cursor(self, mock_get_page):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
 
-        try:
-            next(self.sdk.iter_organization_followers(organization_id))
-        except StopIteration:
-            pass
+        # Simulate cursor-based pagination
+        mock_get_page.side_effect = [
+            {"data": ["follower1", "follower2"], "cursor": "cursor2"},
+            {"data": ["follower3", "follower4"], "cursor": "cursor3"},
+            {"data": ["follower5"]},
+        ]
 
-        self.sdk._request.assert_called_once_with(
-            "GET", f"/organizations/{organization_id}/followers"
+        self.sdk._get_organization_follower_page = mock_get_page
+        iterator = self.sdk.iter_organization_followers(organization_id)
+        results = list(iterator)
+
+        self.assertEqual(
+            results, ["follower1", "follower2", "follower3", "follower4", "follower5"]
         )
+
+        expected_calls = [
+            call(organization_id, size=100),
+            call(organization_id, cursor="cursor2", size=100),
+            call(organization_id, cursor="cursor3", size=100),
+        ]
+        mock_get_page.assert_has_calls(expected_calls)
 
     def test_stop_organization_follower(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -722,16 +722,31 @@ class TestClient(unittest.TestCase):
     # Organization Follower Request
     ###################################################
 
-    def test_iter_organization_follower_requests(self):
+    @patch("zanshinsdk.client.Client._get_organization_follower_request_page")
+    def test_iter_organization_follower_requests(self, mock_get_page):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-        try:
-            next(self.sdk.iter_organization_follower_requests(organization_id))
-        except StopIteration:
-            pass
 
-        self.sdk._request.assert_called_once_with(
-            "GET", f"/organizations/{organization_id}/followers/requests"
+        mock_get_page.side_effect = [
+            {"data": ["request1", "request2"], "cursor": "cursor2"},
+            {"data": ["request3", "request4"], "cursor": "cursor3"},
+            {"data": ["request5"]},
+        ]
+
+        self.sdk._get_organization_follower_request_page = mock_get_page
+        iterator = self.sdk.iter_organization_follower_requests(organization_id)
+        results = list(iterator)
+
+        self.assertEqual(
+            results,
+            ["request1", "request2", "request3", "request4", "request5"],
         )
+
+        expected_calls = [
+            call(organization_id, size=100),
+            call(organization_id, cursor="cursor2", size=100),
+            call(organization_id, cursor="cursor3", size=100),
+        ]
+        mock_get_page.assert_has_calls(expected_calls)
 
     def test_create_organization_follower_request(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -484,13 +484,25 @@ class TestClient(unittest.TestCase):
     # Account API key
     ###################################################
 
-    def test_iter_api_keys(self):
-        try:
-            next(self.sdk.iter_api_keys())
-        except StopIteration:
-            pass
-
-        self.sdk._request.assert_called_once_with("GET", "/me/apikeys")
+    @patch("zanshinsdk.client.Client._get_api_keys_page")
+    def test_iter_api_keys(self, mock_get_page):
+        mock_get_page.side_effect = [
+            {"data": ["key1", "key2"], "cursor": "cursor2"},
+            {"data": ["key3", "key4"], "cursor": "cursor3"},
+            {"data": ["key5"]},
+        ]
+        self.sdk._get_api_keys_page = mock_get_page
+        iterator = self.sdk.iter_api_keys()
+        results = list(iterator)
+        self.assertEqual(
+            results, ["key1", "key2", "key3", "key4", "key5"]
+        )
+        expected_calls = [
+            call(size=100),
+            call(cursor="cursor2", size=100),
+            call(cursor="cursor3", size=100),
+        ]
+        mock_get_page.assert_has_calls(expected_calls)
 
     def test_create_api_key(self):
         name = "MyKey"

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -494,9 +494,7 @@ class TestClient(unittest.TestCase):
         self.sdk._get_api_keys_page = mock_get_page
         iterator = self.sdk.iter_api_keys()
         results = list(iterator)
-        self.assertEqual(
-            results, ["key1", "key2", "key3", "key4", "key5"]
-        )
+        self.assertEqual(results, ["key1", "key2", "key3", "key4", "key5"])
         expected_calls = [
             call(size=100),
             call(cursor="cursor2", size=100),
@@ -524,13 +522,23 @@ class TestClient(unittest.TestCase):
     # Organization
     ###################################################
 
-    def test_iter_organizations(self):
-        try:
-            next(self.sdk.iter_organizations())
-        except StopIteration:
-            pass
-
-        self.sdk._request.assert_called_once_with("GET", "/organizations")
+    @patch("zanshinsdk.client.Client._get_organizations_page")
+    def test_iter_organizations(self, mock_get_page):
+        mock_get_page.side_effect = [
+            {"data": ["org1", "org2"], "cursor": "cursor2"},
+            {"data": ["org3", "org4"], "cursor": "cursor3"},
+            {"data": ["org5"]},
+        ]
+        self.sdk._get_organizations_page = mock_get_page
+        iterator = self.sdk.iter_organizations()
+        results = list(iterator)
+        self.assertEqual(results, ["org1", "org2", "org3", "org4", "org5"])
+        expected_calls = [
+            call(size=100),
+            call(cursor="cursor2", size=100),
+            call(cursor="cursor3", size=100),
+        ]
+        mock_get_page.assert_has_calls(expected_calls)
 
     def test_get_organization(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -458,9 +458,9 @@ class TestClient(unittest.TestCase):
             results, ["invite1", "invite2", "invite3", "invite4", "invite5"]
         )
         expected_calls = [
-            call(size=100),
-            call(cursor="cursor2", size=100),
-            call(cursor="cursor3", size=100),
+            call(size=1000),
+            call(cursor="cursor2", size=1000),
+            call(cursor="cursor3", size=1000),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -496,9 +496,9 @@ class TestClient(unittest.TestCase):
         results = list(iterator)
         self.assertEqual(results, ["key1", "key2", "key3", "key4", "key5"])
         expected_calls = [
-            call(size=100),
-            call(cursor="cursor2", size=100),
-            call(cursor="cursor3", size=100),
+            call(size=1000),
+            call(cursor="cursor2", size=1000),
+            call(cursor="cursor3", size=1000),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -534,9 +534,9 @@ class TestClient(unittest.TestCase):
         results = list(iterator)
         self.assertEqual(results, ["org1", "org2", "org3", "org4", "org5"])
         expected_calls = [
-            call(size=100),
-            call(cursor="cursor2", size=100),
-            call(cursor="cursor3", size=100),
+            call(size=1000),
+            call(cursor="cursor2", size=1000),
+            call(cursor="cursor3", size=1000),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -600,9 +600,9 @@ class TestClient(unittest.TestCase):
             results, ["member1", "member2", "member3", "member4", "member5"]
         )
         expected_calls = [
-            call(organization_id, size=100),
-            call(organization_id, cursor="cursor2", size=100),
-            call(organization_id, cursor="cursor3", size=100),
+            call(organization_id, size=1000),
+            call(organization_id, cursor="cursor2", size=1000),
+            call(organization_id, cursor="cursor3", size=1000),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -679,9 +679,9 @@ class TestClient(unittest.TestCase):
             results, ["invite1", "invite2", "invite3", "invite4", "invite5"]
         )
         expected_calls = [
-            call(organization_id, size=100),
-            call(organization_id, cursor="cursor2", size=100),
-            call(organization_id, cursor="cursor3", size=100),
+            call(organization_id, size=1000),
+            call(organization_id, cursor="cursor2", size=1000),
+            call(organization_id, cursor="cursor3", size=1000),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -748,9 +748,9 @@ class TestClient(unittest.TestCase):
             results, ["follower1", "follower2", "follower3", "follower4", "follower5"]
         )
         expected_calls = [
-            call(organization_id, size=100),
-            call(organization_id, cursor="cursor2", size=100),
-            call(organization_id, cursor="cursor3", size=100),
+            call(organization_id, size=1000),
+            call(organization_id, cursor="cursor2", size=1000),
+            call(organization_id, cursor="cursor3", size=1000),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -788,9 +788,9 @@ class TestClient(unittest.TestCase):
         )
 
         expected_calls = [
-            call(organization_id, size=100),
-            call(organization_id, cursor="cursor2", size=100),
-            call(organization_id, cursor="cursor3", size=100),
+            call(organization_id, size=1000),
+            call(organization_id, cursor="cursor2", size=1000),
+            call(organization_id, cursor="cursor3", size=1000),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -852,9 +852,9 @@ class TestClient(unittest.TestCase):
         )
 
         expected_calls = [
-            call(organization_id, cursor=None, size=100),
-            call(organization_id, cursor="cursor2", size=100),
-            call(organization_id, cursor="cursor3", size=100),
+            call(organization_id, cursor=None, size=1000),
+            call(organization_id, cursor="cursor2", size=1000),
+            call(organization_id, cursor="cursor3", size=1000),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -935,9 +935,9 @@ class TestClient(unittest.TestCase):
             results, ["target1", "target2", "target3", "target4", "target5"]
         )
         expected_calls = [
-            call(organization_id, size=100),
-            call(organization_id, cursor="cursor2", size=100),
-            call(organization_id, cursor="cursor3", size=100),
+            call(organization_id, size=1000),
+            call(organization_id, cursor="cursor2", size=1000),
+            call(organization_id, cursor="cursor3", size=1000),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -1286,9 +1286,9 @@ class TestClient(unittest.TestCase):
         results = list(iterator)
         self.assertEqual(results, ["group1", "group2", "group3", "group4", "group5"])
         expected_calls = [
-            call(organization_id, size=100),
-            call(organization_id, cursor="cursor2", size=100),
-            call(organization_id, cursor="cursor3", size=100),
+            call(organization_id, size=1000),
+            call(organization_id, cursor="cursor2", size=1000),
+            call(organization_id, cursor="cursor3", size=1000),
         ]
         mock_get_groups.assert_has_calls(expected_calls)
 

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -585,17 +585,26 @@ class TestClient(unittest.TestCase):
     # Organization Member
     ###################################################
 
-    def test_iter_organization_members(self):
+    @patch("zanshinsdk.client.Client._get_organization_members_page")
+    def test_iter_organization_members(self, mock_get_page):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-
-        try:
-            next(self.sdk.iter_organization_members(organization_id))
-        except StopIteration:
-            pass
-
-        self.sdk._request.assert_called_once_with(
-            "GET", f"/organizations/{organization_id}/members"
+        mock_get_page.side_effect = [
+            {"data": ["member1", "member2"], "cursor": "cursor2"},
+            {"data": ["member3", "member4"], "cursor": "cursor3"},
+            {"data": ["member5"]},
+        ]
+        self.sdk._get_organization_members_page = mock_get_page
+        iterator = self.sdk.iter_organization_members(organization_id)
+        results = list(iterator)
+        self.assertEqual(
+            results, ["member1", "member2", "member3", "member4", "member5"]
         )
+        expected_calls = [
+            call(organization_id, size=100),
+            call(organization_id, cursor="cursor2", size=100),
+            call(organization_id, cursor="cursor3", size=100),
+        ]
+        mock_get_page.assert_has_calls(expected_calls)
 
     def test_get_organization_members(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -756,17 +756,32 @@ class TestClient(unittest.TestCase):
     # Organization Following
     ###################################################
 
-    def test_iter_organization_following(self):
+    @patch("zanshinsdk.client.Client._get_organization_following_page")
+    def test_iter_organization_following_cursor(self, mock_get_page):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
 
-        try:
-            next(self.sdk.iter_organization_following(organization_id))
-        except StopIteration:
-            pass
+        # Simulate cursor-based pagination
+        mock_get_page.side_effect = [
+            {"data": ["following1", "following2"], "cursor": "cursor2"},
+            {"data": ["following3", "following4"], "cursor": "cursor3"},
+            {"data": ["following5"]},
+        ]
 
-        self.sdk._request.assert_called_once_with(
-            "GET", f"/organizations/{organization_id}/following"
+        self.sdk._get_organization_following_page = mock_get_page
+        iterator = self.sdk.iter_organization_following(organization_id)
+        results = list(iterator)
+
+        self.assertEqual(
+            results,
+            ["following1", "following2", "following3", "following4", "following5"],
         )
+
+        expected_calls = [
+            call(organization_id, cursor=None, size=100),
+            call(organization_id, cursor="cursor2", size=100),
+            call(organization_id, cursor="cursor3", size=100),
+        ]
+        mock_get_page.assert_has_calls(expected_calls)
 
     def test_stop_organization_following(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -664,17 +664,26 @@ class TestClient(unittest.TestCase):
     # Organization Member Invite
     ###################################################
 
-    def test_iter_organization_members_invites(self):
+    @patch("zanshinsdk.client.Client._get_organization_members_invites_page")
+    def test_iter_organization_members_invites(self, mock_get_page):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"
-
-        try:
-            next(self.sdk.iter_organization_members_invites(organization_id))
-        except StopIteration:
-            pass
-
-        self.sdk._request.assert_called_once_with(
-            "GET", f"/organizations/{organization_id}/invites"
+        mock_get_page.side_effect = [
+            {"data": ["invite1", "invite2"], "cursor": "cursor2"},
+            {"data": ["invite3", "invite4"], "cursor": "cursor3"},
+            {"data": ["invite5"]},
+        ]
+        self.sdk._get_organization_members_invites_page = mock_get_page
+        iterator = self.sdk.iter_organization_members_invites(organization_id)
+        results = list(iterator)
+        self.assertEqual(
+            results, ["invite1", "invite2", "invite3", "invite4", "invite5"]
         )
+        expected_calls = [
+            call(organization_id, size=100),
+            call(organization_id, cursor="cursor2", size=100),
+            call(organization_id, cursor="cursor3", size=100),
+        ]
+        mock_get_page.assert_has_calls(expected_calls)
 
     def test_create_organization_members_invite(self):
         organization_id = "822f4225-43e9-4922-b6b8-8b0620bdb1e3"


### PR DESCRIPTION
This pull request significantly improves the pagination handling in the `zanshinsdk.client` module by introducing internal helper methods for paginated endpoints and updating all relevant iterator methods to use these helpers. This ensures consistent, efficient retrieval of data across multiple API resources, especially for large datasets. Additionally, pre-commit hook versions are updated for better code quality tooling.

**Pagination and API Client Improvements:**

* Introduced internal helper methods (e.g., `_get_invite_page`, `_get_api_keys_page`, `_get_organizations_page`, etc.) to handle paginated API responses for invites, API keys, organizations, organization members, invites, followers, follower requests, following, scan targets, and scan target groups. These helpers standardize pagination logic and validation. 

* Updated all corresponding iterator methods (e.g., `iter_invites`, `iter_api_keys`, `iter_organizations`, etc.) to use these new helper methods, enabling seamless iteration over paginated results and improving scalability for large result sets.

**Tooling and Dependency Updates:**

* Updated pre-commit hook versions for `isort`, `black`, `flake8`, and `pre-commit-hooks` in `.pre-commit-config.yaml` to ensure up-to-date code formatting and linting tools.

**Minor Code Quality Improvements:**

* Added a missing newline at the top of `zanshinsdk/alerts_history.py` for PEP8 compliance.

#### Related

Issue #184 