### PR TITLE
fix: pagination bug

### DIFF
--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -10,7 +10,7 @@ from math import ceil
 from os import environ
 from os.path import isfile
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, Optional, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Union
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -363,6 +363,30 @@ class Client:
         response.raise_for_status()
         return response
 
+    def _paginate(
+        self, fetch_func: Callable[..., Any], size: int = 1000, **kwargs
+    ) -> Iterator[Dict]:
+        """
+        A generalized helper to handle API pagination.
+        :param fetch_func: The specific internal method to call for a page of data.
+        :param size: the number of items per page
+        :param kwargs: Additional arguments to pass to the fetch_func (e.g., organization_id).
+        """
+        page = fetch_func(size=size, **kwargs)
+
+        if isinstance(page, list):
+            yield from page
+            return
+
+        if not page.get("data"):
+            return
+
+        yield from page.get("data", [])
+
+        while page.get("cursor"):
+            page = fetch_func(cursor=page["cursor"], size=size, **kwargs)
+            yield from page.get("data", [])
+
     ###################################################
     # Account
     ###################################################
@@ -394,20 +418,14 @@ class Client:
             params["cursor"] = cursor
         return self._request("GET", "/me/invites", params=params).json()
 
-    def iter_invites(self) -> Iterator[Dict]:
+    def iter_invites(self, size: int = 1000) -> Iterator[Dict]:
         """
         Iterates over the invites of current logged user.
         <https://api.zanshin.tenchisecurity.com/#operation/getInvites>
+        :param size: the number of items per page
         :return: an iterator over the invites objects
         """
-        page = self._get_invite_page(size=1000)
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_invite_page(cursor=page["cursor"], size=1000)
-            yield from page.get("data", [])
+        return self._paginate(self._get_invite_page, size=size)
 
     def get_invite(self, invite_id: Union[UUID, str]) -> Dict:
         """
@@ -451,20 +469,14 @@ class Client:
             params["cursor"] = cursor
         return self._request("GET", "/me/apikeys", params=params).json()
 
-    def iter_api_keys(self) -> Iterator[Dict]:
+    def iter_api_keys(self, size: int = 1000) -> Iterator[Dict]:
         """
         Iterates over the API keys of current logged user.
         <https://api.zanshin.tenchisecurity.com/#operation/getMyApiKeys>
+        :param size: the number of items per page
         :return: an iterator over the api keys objects
         """
-        page = self._get_api_keys_page(size=1000)
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_api_keys_page(cursor=page["cursor"], size=1000)
-            yield from page.get("data", [])
+        return self._paginate(self._get_api_keys_page, size=size)
 
     def create_api_key(self, name: Optional[str]) -> Dict:
         """
@@ -493,7 +505,7 @@ class Client:
     ###################################################
 
     def _get_organizations_page(
-        self, cursor: Optional[str] = None, size: int = 100
+        self, cursor: Optional[str] = None, size: int = 1000
     ) -> Dict:
         """
         Internal method to get a page of the organizations of current logged user.
@@ -509,20 +521,14 @@ class Client:
             params["cursor"] = cursor
         return self._request("GET", "/organizations", params=params).json()
 
-    def iter_organizations(self) -> Iterator[Dict]:
+    def iter_organizations(self, size: int = 1000) -> Iterator[Dict]:
         """
         Iterates over organizations of current logged user.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizations>
+        :param size: the number of items per page
         :return: an iterator over the organizations objects
         """
-        page = self._get_organizations_page(size=1000)
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_organizations_page(cursor=page["cursor"], size=1000)
-            yield from page.get("data", [])
+        return self._paginate(self._get_organizations_page, size=size)
 
     def get_organization(self, organization_id: Union[UUID, str]) -> Dict:
         """
@@ -606,24 +612,20 @@ class Client:
         ).json()
 
     def iter_organization_members(
-        self, organization_id: Union[UUID, str]
+        self, organization_id: Union[UUID, str], size: int = 1000
     ) -> Iterator[Dict]:
         """
         Iterates over the users which are members of an organization.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationMembers>
         :param organization_id: the ID of the organization
+        :param size: the number of items per page
         :return: an iterator over the organization members objects
         """
-        page = self._get_organization_members_page(organization_id, size=1000)
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_organization_members_page(
-                organization_id, cursor=page["cursor"], size=1000
-            )
-            yield from page.get("data", [])
+        return self._paginate(
+            self._get_organization_members_page,
+            size=size,
+            organization_id=organization_id,
+        )
 
     def get_organization_member(
         self, organization_id: Union[UUID, str], member_id: Union[UUID, str]
@@ -741,24 +743,20 @@ class Client:
         ).json()
 
     def iter_organization_members_invites(
-        self, organization_id: Union[UUID, str]
+        self, organization_id: Union[UUID, str], size: int = 1000
     ) -> Iterator[Dict]:
         """
         Iterates over the members invites of an organization.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrgamizationInvites>
         :param organization_id: the ID of the organization
+        :param size: the number of items per page
         :return: an iterator over the organization members invites objects
         """
-        page = self._get_organization_members_invites_page(organization_id, size=1000)
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_organization_members_invites_page(
-                organization_id, cursor=page["cursor"], size=1000
-            )
-            yield from page.get("data", [])
+        return self._paginate(
+            self._get_organization_members_invites_page,
+            size=size,
+            organization_id=organization_id,
+        )
 
     def create_organization_members_invite(
         self,
@@ -857,24 +855,20 @@ class Client:
         ).json()
 
     def iter_organization_followers(
-        self, organization_id: Union[UUID, str]
+        self, organization_id: Union[UUID, str], size: int = 1000
     ) -> Iterator[Dict]:
         """
         Iterates over the followers of an organization.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationFollowers>
         :param organization_id: the ID of the organization
+        :param size: the number of items per page
         :return: an iterator over the organization followers objects
         """
-        page = self._get_organization_follower_page(organization_id, size=1000)
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_organization_follower_page(
-                organization_id, cursor=page["cursor"], size=1000
-            )
-            yield from page.get("data", [])
+        return self._paginate(
+            self._get_organization_follower_page,
+            size=size,
+            organization_id=organization_id,
+        )
 
     def stop_organization_follower(
         self, organization_id: Union[UUID, str], follower_id: Union[UUID, str]
@@ -922,24 +916,20 @@ class Client:
         ).json()
 
     def iter_organization_follower_requests(
-        self, organization_id: Union[UUID, str]
+        self, organization_id: Union[UUID, str], size: int = 1000
     ) -> Iterator[Dict]:
         """
         Iterates over the follower requests of an organization.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationFollowRequests>
         :param organization_id: the ID of the organization
+        :param size: the number of items per page
         :return: an iterator over the organization follower requests objects
         """
-        page = self._get_organization_follower_request_page(organization_id, size=1000)
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_organization_follower_request_page(
-                organization_id, cursor=page["cursor"], size=1000
-            )
-            yield from page.get("data", [])
+        return self._paginate(
+            self._get_organization_follower_request_page,
+            size=size,
+            organization_id=organization_id,
+        )
 
     def create_organization_follower_request(
         self, organization_id: Union[UUID, str], token: Union[UUID, str]
@@ -1021,26 +1011,20 @@ class Client:
         ).json()
 
     def iter_organization_following(
-        self, organization_id: Union[UUID, str]
+        self, organization_id: Union[UUID, str], size: int = 1000
     ) -> Iterator[Dict]:
         """
         Iterates over the following of an organization.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationFollowing>
         :param organization_id: the ID of the organization whose followed organizations we should list
+        :param size: the number of items per page
         :return: an iterator over the JSON decoded followed organizations
         """
-        page = self._get_organization_following_page(
-            organization_id, cursor=None, size=1000
+        return self._paginate(
+            self._get_organization_following_page,
+            size=size,
+            organization_id=organization_id,
         )
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_organization_following_page(
-                organization_id, cursor=page["cursor"], size=1000
-            )
-            yield from page.get("data", [])
 
     def stop_organization_following(
         self, organization_id: Union[UUID, str], following_id: Union[UUID, str]
@@ -1153,24 +1137,20 @@ class Client:
         ).json()
 
     def iter_organization_scan_targets(
-        self, organization_id: Union[UUID, str]
+        self, organization_id: Union[UUID, str], size: int = 1000
     ) -> Iterator[Dict]:
         """
         Iterates over the scan targets of an organization.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationScanTargets>
         :param organization_id: the ID of the organization
+        :param size: the number of items per page
         : return: an iterator over the scan target objects
         """
-        page = self._get_organization_scan_targets_page(organization_id, size=1000)
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_organization_scan_targets_page(
-                organization_id, cursor=page["cursor"], size=1000
-            )
-            yield from page.get("data", [])
+        return self._paginate(
+            self._get_organization_scan_targets_page,
+            size=size,
+            organization_id=organization_id,
+        )
 
     def create_organization_scan_target(
         self,
@@ -1509,26 +1489,20 @@ class Client:
         ).json()
 
     def iter_organization_scan_target_groups(
-        self, organization_id: Union[UUID, str]
+        self, organization_id: Union[UUID, str], size: int = 1000
     ) -> Iterator[Dict]:
         """
         Iterates over the scan targets groups.
         <https://api.zanshin.tenchisecurity.com/#operation/getOrganizationScanTargetGroups>
         :param organization_id: the ID of the organization
+        :param size: the number of items per page
         : return: an iterator over the scan target groups
         """
-        page = self._get_organization_scan_target_groups_page(
-            organization_id, size=1000
+        return self._paginate(
+            self._get_organization_scan_target_groups_page,
+            size=size,
+            organization_id=organization_id,
         )
-        if isinstance(page, list) or not page.get("data"):
-            yield from page
-            return
-        yield from page.get("data", [])
-        while page.get("cursor"):
-            page = self._get_organization_scan_target_groups_page(
-                organization_id, cursor=page["cursor"], size=1000
-            )
-            yield from page.get("data", [])
 
     def get_organization_scan_target_group(
         self, organization_id: Union[UUID, str], scan_target_group_id: Union[UUID, str]

--- a/zanshinsdk/client.py
+++ b/zanshinsdk/client.py
@@ -365,7 +365,7 @@ class Client:
 
     def _paginate(
         self, fetch_func: Callable[..., Any], size: int = 1000, **kwargs
-    ) -> Iterator[Dict]:
+    ) -> Iterator[Any]:
         """
         A generalized helper to handle API pagination.
         :param fetch_func: The specific internal method to call for a page of data.

--- a/zanshinsdk/tests/test_client.py
+++ b/zanshinsdk/tests/test_client.py
@@ -432,6 +432,43 @@ class TestClient(unittest.TestCase):
         )
 
     ###################################################
+    # Pagination Helper (_paginate) Tests
+    ###################################################
+
+    def test_paginate_returns_raw_list(self):
+        """Test that _paginate yields properly if the API returns a raw list."""
+        mock_fetch = Mock(return_value=["item1", "item2"])
+        iterator = self.sdk._paginate(mock_fetch)
+        self.assertEqual(list(iterator), ["item1", "item2"])
+        mock_fetch.assert_called_once_with(size=1000)
+
+    def test_paginate_returns_empty_dict(self):
+        """Test that _paginate stops if the API returns a dictionary with no data key."""
+        mock_fetch = Mock(return_value={})
+        iterator = self.sdk._paginate(mock_fetch)
+        self.assertEqual(list(iterator), [])
+        mock_fetch.assert_called_once_with(size=1000)
+
+    def test_paginate_returns_empty_data_list(self):
+        """
+        Test that _paginate stops cleanly on empty data list.
+        This explicitly covers the bug where 'yield from {"data": []}' yielded the "data" key.
+        """
+        mock_fetch = Mock(return_value={"data": [], "cursor": None})
+        iterator = self.sdk._paginate(mock_fetch)
+        self.assertEqual(list(iterator), [])
+        mock_fetch.assert_called_once_with(size=1000)
+
+    def test_paginate_kwargs_passing(self):
+        """Test that _paginate passes custom size and arbitrary kwargs through to the fetch function."""
+        mock_fetch = Mock(return_value={"data": ["item1"], "cursor": None})
+        iterator = self.sdk._paginate(
+            mock_fetch, size=50, custom_arg="foo", org_id="bar"
+        )
+        self.assertEqual(list(iterator), ["item1"])
+        mock_fetch.assert_called_once_with(size=50, custom_arg="foo", org_id="bar")
+
+    ###################################################
     # Account
     ###################################################
 
@@ -600,9 +637,9 @@ class TestClient(unittest.TestCase):
             results, ["member1", "member2", "member3", "member4", "member5"]
         )
         expected_calls = [
-            call(organization_id, size=1000),
-            call(organization_id, cursor="cursor2", size=1000),
-            call(organization_id, cursor="cursor3", size=1000),
+            call(size=1000, organization_id=organization_id),
+            call(cursor="cursor2", size=1000, organization_id=organization_id),
+            call(cursor="cursor3", size=1000, organization_id=organization_id),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -679,9 +716,9 @@ class TestClient(unittest.TestCase):
             results, ["invite1", "invite2", "invite3", "invite4", "invite5"]
         )
         expected_calls = [
-            call(organization_id, size=1000),
-            call(organization_id, cursor="cursor2", size=1000),
-            call(organization_id, cursor="cursor3", size=1000),
+            call(size=1000, organization_id=organization_id),
+            call(cursor="cursor2", size=1000, organization_id=organization_id),
+            call(cursor="cursor3", size=1000, organization_id=organization_id),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -748,9 +785,9 @@ class TestClient(unittest.TestCase):
             results, ["follower1", "follower2", "follower3", "follower4", "follower5"]
         )
         expected_calls = [
-            call(organization_id, size=1000),
-            call(organization_id, cursor="cursor2", size=1000),
-            call(organization_id, cursor="cursor3", size=1000),
+            call(size=1000, organization_id=organization_id),
+            call(cursor="cursor2", size=1000, organization_id=organization_id),
+            call(cursor="cursor3", size=1000, organization_id=organization_id),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -788,9 +825,9 @@ class TestClient(unittest.TestCase):
         )
 
         expected_calls = [
-            call(organization_id, size=1000),
-            call(organization_id, cursor="cursor2", size=1000),
-            call(organization_id, cursor="cursor3", size=1000),
+            call(size=1000, organization_id=organization_id),
+            call(cursor="cursor2", size=1000, organization_id=organization_id),
+            call(cursor="cursor3", size=1000, organization_id=organization_id),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -852,9 +889,9 @@ class TestClient(unittest.TestCase):
         )
 
         expected_calls = [
-            call(organization_id, cursor=None, size=1000),
-            call(organization_id, cursor="cursor2", size=1000),
-            call(organization_id, cursor="cursor3", size=1000),
+            call(size=1000, organization_id=organization_id),
+            call(cursor="cursor2", size=1000, organization_id=organization_id),
+            call(cursor="cursor3", size=1000, organization_id=organization_id),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -935,9 +972,9 @@ class TestClient(unittest.TestCase):
             results, ["target1", "target2", "target3", "target4", "target5"]
         )
         expected_calls = [
-            call(organization_id, size=1000),
-            call(organization_id, cursor="cursor2", size=1000),
-            call(organization_id, cursor="cursor3", size=1000),
+            call(size=1000, organization_id=organization_id),
+            call(cursor="cursor2", size=1000, organization_id=organization_id),
+            call(cursor="cursor3", size=1000, organization_id=organization_id),
         ]
         mock_get_page.assert_has_calls(expected_calls)
 
@@ -1286,9 +1323,9 @@ class TestClient(unittest.TestCase):
         results = list(iterator)
         self.assertEqual(results, ["group1", "group2", "group3", "group4", "group5"])
         expected_calls = [
-            call(organization_id, size=1000),
-            call(organization_id, cursor="cursor2", size=1000),
-            call(organization_id, cursor="cursor3", size=1000),
+            call(size=1000, organization_id=organization_id),
+            call(cursor="cursor2", size=1000, organization_id=organization_id),
+            call(cursor="cursor3", size=1000, organization_id=organization_id),
         ]
         mock_get_groups.assert_has_calls(expected_calls)
 


### PR DESCRIPTION
When the page is empty (page: []), the iterator was iterating through the dict, instead of the list.

e.g.:

<img width="881" height="269" alt="Image" src="https://github.com/user-attachments/assets/9d57943c-a50b-4f2d-b0c4-e6c098a6752f" />

<img width="1151" height="268" alt="Image" src="https://github.com/user-attachments/assets/0f001957-46d6-4d01-b05e-a8893e607d00" />
(should not return "data" as scan target)

issue: https://github.com/tenchi-security/zanshin-api/issues/4421